### PR TITLE
fix(dashboards): correct prod panel 163

### DIFF
--- a/terraform/dashboards/Near/chain-signatures/chain_sig_prod.json
+++ b/terraform/dashboards/Near/chain-signatures/chain_sig_prod.json
@@ -128,15 +128,21 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "percent",
-          "decimals": 2,
-          "min": 0,
-          "max": 100,
+          "custom": {
+            "align": "auto",
+            "footer": {
+              "reducers": []
+            },
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "value": 0,
+                "value": null,
                 "color": "dark-red"
               },
               {
@@ -149,18 +155,12 @@
               }
             ]
           },
+          "unit": "percent",
+          "decimals": 2,
+          "min": 0,
+          "max": 100,
           "color": {
             "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "footer": {
-              "reducers": []
-            },
-            "inspect": false
           }
         },
         "overrides": [
@@ -220,9 +220,9 @@
         ]
       },
       "options": {
+        "showHeader": true,
         "cellHeight": "sm",
         "enablePagination": false,
-        "showHeader": true,
         "sortBy": [
           {
             "desc": true,


### PR DESCRIPTION
## Summary
- correct panel 163 in the production Chain Signatures dashboard
- align the table panel config with the working Grafana panel export
- fix the PromQL string formatting used in the provisioned dashboard JSON

## Validation
- jq empty terraform/dashboards/Near/chain-signatures/chain_sig_prod.json
- terraform validate