### PR TITLE
fix(dashboards): align prod panel 163 with classic JSON

### DIFF
--- a/terraform/dashboards/Near/chain-signatures/chain_sig_prod.json
+++ b/terraform/dashboards/Near/chain-signatures/chain_sig_prod.json
@@ -87,41 +87,32 @@
       ],
       "transformations": [
         {
-          "kind": "Transformation",
-          "group": "labelsToFields",
-          "spec": {
-            "options": {
-              "mode": "columns"
-            }
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns"
           }
         },
         {
-          "kind": "Transformation",
-          "group": "merge",
-          "spec": {
-            "options": {}
-          }
+          "id": "merge",
+          "options": {}
         },
         {
-          "kind": "Transformation",
-          "group": "organize",
-          "spec": {
-            "options": {
-              "excludeByName": {
-                "Time": true,
-                "short_hash": true
-              },
-              "indexByName": {
-                "chain": 1,
-                "git_commit_hash": 2,
-                "version": 0
-              },
-              "renameByName": {
-                "Value": "SLI",
-                "chain": "Chain",
-                "git_commit_hash": "Commit Hash",
-                "version": "Version"
-              }
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "short_hash": true
+            },
+            "indexByName": {
+              "chain": 1,
+              "git_commit_hash": 2,
+              "version": 0
+            },
+            "renameByName": {
+              "Value": "SLI",
+              "chain": "Chain",
+              "git_commit_hash": "Commit Hash",
+              "version": "Version"
             }
           }
         }

--- a/terraform/dashboards/Near/chain-signatures/chain_sig_prod.json
+++ b/terraform/dashboards/Near/chain-signatures/chain_sig_prod.json
@@ -172,7 +172,6 @@
           {
             "matcher": {
               "id": "byName",
-              "scope": "series",
               "options": "Version"
             },
             "properties": [
@@ -185,7 +184,6 @@
           {
             "matcher": {
               "id": "byName",
-              "scope": "series",
               "options": "Chain"
             },
             "properties": [
@@ -198,7 +196,6 @@
           {
             "matcher": {
               "id": "byName",
-              "scope": "series",
               "options": "Commit Hash"
             },
             "properties": [


### PR DESCRIPTION
## Summary
- convert panel 163 transformations to classic dashboard JSON format
- remove V2-only matcher scope fields from panel 163 overrides
- keep the existing panel query and layout intact

## Why
Panel 163 in `main` still carried V2-style transformation and matcher metadata after PR #32 merged. The staging/provisioned dashboard path uses classic dashboard JSON, and Grafana errors when it encounters those V2 shapes there.

## Validation
- jq empty terraform/dashboards/Near/chain-signatures/chain_sig_prod.json
- terraform validate