### PR TITLE
feat(dashboards): auto-sync chain signatures prod export

### DIFF
--- a/.github/workflows/sync-chain-signatures-prod-dashboard.yaml
+++ b/.github/workflows/sync-chain-signatures-prod-dashboard.yaml
@@ -1,0 +1,53 @@
+name: Sync Chain Signatures Prod Dashboard
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+    paths:
+      - "terraform/dashboards/Near/chain-signatures/chain_sig_prod.json"
+
+concurrency:
+  group: sync-chain-signatures-prod-dashboard-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  sync-prod-dashboard:
+    name: Normalize prod dashboard export
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - name: Load base prod dashboard reference
+        run: |
+          git fetch origin "${{ github.event.pull_request.base.ref }}"
+          git show "origin/${{ github.event.pull_request.base.ref }}:terraform/dashboards/Near/chain-signatures/chain_sig_prod.json" > /tmp/chain_sig_prod.reference.json
+
+      - name: Normalize prod dashboard fields
+        run: |
+          python3 scripts/sync_chain_sig_prod.py \
+            --candidate terraform/dashboards/Near/chain-signatures/chain_sig_prod.json \
+            --reference /tmp/chain_sig_prod.reference.json
+
+      - name: Commit normalized dashboard
+        run: |
+          if git diff --quiet -- terraform/dashboards/Near/chain-signatures/chain_sig_prod.json; then
+            echo "No dashboard changes to commit."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add terraform/dashboards/Near/chain-signatures/chain_sig_prod.json
+          git commit -m "chore(dashboards): sync chain signatures prod export"
+          git push origin "HEAD:${{ github.event.pull_request.head.ref }}"

--- a/scripts/sync_chain_sig_prod.py
+++ b/scripts/sync_chain_sig_prod.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+from pathlib import Path
+
+
+REFERENCE_FIELDS = (
+    ("apiVersion",),
+    ("kind",),
+    ("metadata",),
+    ("spec", "title"),
+    ("spec", "editable"),
+)
+
+
+def load_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def dump_json(path: Path, document: dict) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(document, handle, indent=2, ensure_ascii=False)
+        handle.write("\n")
+
+
+def validate_dashboard(document: dict, label: str) -> None:
+    if document.get("apiVersion") != "dashboard.grafana.app/v2":
+        raise ValueError(f"{label} must be a Grafana v2 dashboard export")
+    if document.get("kind") != "Dashboard":
+        raise ValueError(f"{label} must have kind=Dashboard")
+    if not isinstance(document.get("metadata"), dict):
+        raise ValueError(f"{label} must include a metadata object")
+    if not isinstance(document.get("spec"), dict):
+        raise ValueError(f"{label} must include a spec object")
+
+
+def read_path(document: dict, path: tuple[str, ...]):
+    current = document
+    for key in path:
+        if not isinstance(current, dict) or key not in current:
+            raise KeyError("Missing required field: " + ".".join(path))
+        current = current[key]
+    return current
+
+
+def write_path(document: dict, path: tuple[str, ...], value) -> None:
+    current = document
+    for key in path[:-1]:
+        if key not in current or not isinstance(current[key], dict):
+            current[key] = {}
+        current = current[key]
+    current[path[-1]] = value
+
+
+def normalize_dashboard(candidate: dict, reference: dict) -> dict:
+    for field in REFERENCE_FIELDS:
+        write_path(candidate, field, read_path(reference, field))
+    return candidate
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Sync the Chain Signatures prod dashboard with staging content while "
+            "preserving the deployed prod identity fields."
+        )
+    )
+    parser.add_argument("--candidate", required=True, type=Path)
+    parser.add_argument("--reference", required=True, type=Path)
+    args = parser.parse_args()
+
+    candidate = load_json(args.candidate)
+    reference = load_json(args.reference)
+    validate_dashboard(candidate, "Candidate dashboard")
+    validate_dashboard(reference, "Reference dashboard")
+    normalized = normalize_dashboard(candidate, reference)
+    dump_json(args.candidate, normalized)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a PR workflow that normalizes `chain_sig_prod.json` on same-repo PRs
- preserve the deployed prod dashboard identity fields from the base branch while keeping pasted staging content
- fail fast if the candidate file is not a Grafana v2 dashboard export

## Verification
- `python3 -m py_compile scripts/sync_chain_sig_prod.py`
- simulated staging export normalized against current prod reference locally