### PR TITLE
fix(alerts): keep mainnet signature sli on last state

### DIFF
--- a/terraform/alerts/Near/chain-signatures/success rates.tf
+++ b/terraform/alerts/Near/chain-signatures/success rates.tf
@@ -116,7 +116,7 @@ resource "grafana_rule_group" "rule_group_ab5e7f79a1339a71" {
       })
     }
 
-    no_data_state  = "NoData"
+    no_data_state  = "KeepLast"
     exec_err_state = "Error"
     for            = "5m"
     annotations = {
@@ -245,7 +245,7 @@ resource "grafana_rule_group" "rule_group_ab5e7f79a1339a71" {
       })
     }
 
-    no_data_state  = "NoData"
+    no_data_state  = "KeepLast"
     exec_err_state = "Error"
     for            = "5m"
     annotations = {
@@ -374,7 +374,7 @@ resource "grafana_rule_group" "rule_group_ab5e7f79a1339a71" {
       })
     }
 
-    no_data_state  = "NoData"
+    no_data_state  = "KeepLast"
     exec_err_state = "Error"
     for            = "5m"
     annotations = {


### PR DESCRIPTION
## Summary
- change the mainnet signature SLI alerts to keep their last state on no-data
- avoid paging on no-data events for the ETH, Solana, and Hydration mainnet signature SR rules

## Verification
- `terraform init -backend=false -input=false`
- `terraform validate` in `terraform/alerts/Near/chain-signatures`