### PR TITLE
fix(alerts): suppress mainnet signature SLI no-data pages

### DIFF
--- a/terraform/alerts/Near/chain-signatures/success rates.tf
+++ b/terraform/alerts/Near/chain-signatures/success rates.tf
@@ -24,10 +24,21 @@ resource "grafana_rule_group" "rule_group_ab5e7f79a1339a71" {
         }
         editorMode    = "code"
         expr          = <<-EOT
-          (sum(increase(multichain_sign_request_latency_sec_count{environment="mainnet", chain="Ethereum", step="total", status="in_time"}[1h]))
-          / (sum(increase(multichain_sign_request_latency_sec_count{environment="mainnet", chain="Ethereum", step="total", status="in_time"}[1h]))
-            + (sum(increase(multichain_sign_request_delayed{environment="mainnet", chain="Ethereum"}[1h]))
-              or (0 * sum(increase(multichain_sign_request_latency_sec_count{environment="mainnet", chain="Ethereum", step="total", status="in_time"}[1h])))))) * 100
+          (
+            (((sum(increase(multichain_sign_request_latency_sec_count{environment="mainnet", chain="Ethereum", step="total", status="in_time"}[1h])) or vector(0))
+            + (sum(increase(multichain_sign_request_delayed{environment="mainnet", chain="Ethereum"}[1h])) or vector(0))) > bool 0)
+            * (
+              ((sum(increase(multichain_sign_request_latency_sec_count{environment="mainnet", chain="Ethereum", step="total", status="in_time"}[1h])) or vector(0))
+              / clamp_min(
+                ((sum(increase(multichain_sign_request_latency_sec_count{environment="mainnet", chain="Ethereum", step="total", status="in_time"}[1h])) or vector(0))
+                + (sum(increase(multichain_sign_request_delayed{environment="mainnet", chain="Ethereum"}[1h])) or vector(0))),
+                1
+              )) * 100
+            )
+          ) + (
+            (((sum(increase(multichain_sign_request_latency_sec_count{environment="mainnet", chain="Ethereum", step="total", status="in_time"}[1h])) or vector(0))
+            + (sum(increase(multichain_sign_request_delayed{environment="mainnet", chain="Ethereum"}[1h])) or vector(0))) == bool 0) * 100
+          )
         EOT
         instant       = false
         interval      = ""
@@ -116,7 +127,7 @@ resource "grafana_rule_group" "rule_group_ab5e7f79a1339a71" {
       })
     }
 
-    no_data_state  = "KeepLast"
+    no_data_state  = "OK"
     exec_err_state = "Error"
     for            = "5m"
     annotations = {
@@ -153,10 +164,21 @@ resource "grafana_rule_group" "rule_group_ab5e7f79a1339a71" {
         }
         editorMode    = "code"
         expr          = <<-EOT
-          (sum(increase(multichain_sign_request_latency_sec_count{environment="mainnet", chain="Solana", step="total", status="in_time"}[1h]))
-          / (sum(increase(multichain_sign_request_latency_sec_count{environment="mainnet", chain="Solana", step="total", status="in_time"}[1h]))
-            + (sum(increase(multichain_sign_request_delayed{environment="mainnet", chain="Solana"}[1h]))
-              or (0 * sum(increase(multichain_sign_request_latency_sec_count{environment="mainnet", chain="Solana", step="total", status="in_time"}[1h])))))) * 100
+          (
+            (((sum(increase(multichain_sign_request_latency_sec_count{environment="mainnet", chain="Solana", step="total", status="in_time"}[1h])) or vector(0))
+            + (sum(increase(multichain_sign_request_delayed{environment="mainnet", chain="Solana"}[1h])) or vector(0))) > bool 0)
+            * (
+              ((sum(increase(multichain_sign_request_latency_sec_count{environment="mainnet", chain="Solana", step="total", status="in_time"}[1h])) or vector(0))
+              / clamp_min(
+                ((sum(increase(multichain_sign_request_latency_sec_count{environment="mainnet", chain="Solana", step="total", status="in_time"}[1h])) or vector(0))
+                + (sum(increase(multichain_sign_request_delayed{environment="mainnet", chain="Solana"}[1h])) or vector(0))),
+                1
+              )) * 100
+            )
+          ) + (
+            (((sum(increase(multichain_sign_request_latency_sec_count{environment="mainnet", chain="Solana", step="total", status="in_time"}[1h])) or vector(0))
+            + (sum(increase(multichain_sign_request_delayed{environment="mainnet", chain="Solana"}[1h])) or vector(0))) == bool 0) * 100
+          )
         EOT
         instant       = false
         interval      = ""
@@ -245,7 +267,7 @@ resource "grafana_rule_group" "rule_group_ab5e7f79a1339a71" {
       })
     }
 
-    no_data_state  = "KeepLast"
+    no_data_state  = "OK"
     exec_err_state = "Error"
     for            = "5m"
     annotations = {
@@ -282,10 +304,21 @@ resource "grafana_rule_group" "rule_group_ab5e7f79a1339a71" {
         }
         editorMode    = "code"
         expr          = <<-EOT
-          (sum(increase(multichain_sign_request_latency_sec_count{environment="mainnet", chain="Hydration", step="total", status="in_time"}[1h]))
-          / (sum(increase(multichain_sign_request_latency_sec_count{environment="mainnet", chain="Hydration", step="total", status="in_time"}[1h]))
-            + (sum(increase(multichain_sign_request_delayed{environment="mainnet", chain="Hydration"}[1h]))
-              or (0 * sum(increase(multichain_sign_request_latency_sec_count{environment="mainnet", chain="Hydration", step="total", status="in_time"}[1h])))))) * 100
+          (
+            (((sum(increase(multichain_sign_request_latency_sec_count{environment="mainnet", chain="Hydration", step="total", status="in_time"}[1h])) or vector(0))
+            + (sum(increase(multichain_sign_request_delayed{environment="mainnet", chain="Hydration"}[1h])) or vector(0))) > bool 0)
+            * (
+              ((sum(increase(multichain_sign_request_latency_sec_count{environment="mainnet", chain="Hydration", step="total", status="in_time"}[1h])) or vector(0))
+              / clamp_min(
+                ((sum(increase(multichain_sign_request_latency_sec_count{environment="mainnet", chain="Hydration", step="total", status="in_time"}[1h])) or vector(0))
+                + (sum(increase(multichain_sign_request_delayed{environment="mainnet", chain="Hydration"}[1h])) or vector(0))),
+                1
+              )) * 100
+            )
+          ) + (
+            (((sum(increase(multichain_sign_request_latency_sec_count{environment="mainnet", chain="Hydration", step="total", status="in_time"}[1h])) or vector(0))
+            + (sum(increase(multichain_sign_request_delayed{environment="mainnet", chain="Hydration"}[1h])) or vector(0))) == bool 0) * 100
+          )
         EOT
         instant       = false
         interval      = ""
@@ -374,7 +407,7 @@ resource "grafana_rule_group" "rule_group_ab5e7f79a1339a71" {
       })
     }
 
-    no_data_state  = "KeepLast"
+    no_data_state  = "OK"
     exec_err_state = "Error"
     for            = "5m"
     annotations = {


### PR DESCRIPTION
## Summary
- stop the three mainnet signature SLI alerts from producing a no-data paging path
- make the PromQL return `100` when there were zero requests in the last hour instead of yielding an empty series
- set `no_data_state` to `OK` for those rules so Grafana treats missing data as non-paging for this SLI

## Why
Grafana docs distinguish `Keep Last State` from `Normal/OK`: `Keep Last State` preserves the prior state, but it does not make an empty query produce a value. These three rules could still evaluate to an empty series when request volume was zero or samples disappeared, which leaves room for no-data behavior instead of a stable SLI result.

## Verification
- `terraform -chdir=terraform/alerts/Near/chain-signatures fmt "success rates.tf"`
- `terraform -chdir=terraform/alerts/Near/chain-signatures init -backend=false -input=false`
- `terraform -chdir=terraform/alerts/Near/chain-signatures validate`

## Notes
I could not query the live Grafana rule payload from this session because the active GCP service account lacks Secret Manager access to the Grafana URL/token secrets.