### PR TITLE
fix(alerts): suppress mainnet app alert no-data pages

### DIFF
--- a/terraform/alerts/Near/chain-signatures/multichain_default_1m.tf
+++ b/terraform/alerts/Near/chain-signatures/multichain_default_1m.tf
@@ -95,7 +95,7 @@ resource "grafana_rule_group" "rule_group_52a0e1fab90ce868" {
       model          = "{\"conditions\":[{\"evaluator\":{\"params\":[10],\"type\":\"lt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[\"C\"]},\"reducer\":{\"params\":[],\"type\":\"last\"},\"type\":\"query\"}],\"datasource\":{\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"B\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"refId\":\"C\",\"type\":\"threshold\"}"
     }
 
-    no_data_state  = "KeepLast"
+    no_data_state  = "OK"
     exec_err_state = "Error"
     for            = "10m"
     annotations = {
@@ -148,7 +148,7 @@ resource "grafana_rule_group" "rule_group_52a0e1fab90ce868" {
       model          = "{\"conditions\":[{\"evaluator\":{\"params\":[10],\"type\":\"lt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[\"C\"]},\"reducer\":{\"params\":[],\"type\":\"last\"},\"type\":\"query\"}],\"datasource\":{\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"B\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"refId\":\"C\",\"type\":\"threshold\"}"
     }
 
-    no_data_state  = "KeepLast"
+    no_data_state  = "OK"
     exec_err_state = "Error"
     for            = "10m"
     annotations = {
@@ -201,7 +201,7 @@ resource "grafana_rule_group" "rule_group_52a0e1fab90ce868" {
       model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0.95],\"type\":\"lt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[\"C\"]},\"reducer\":{\"params\":[],\"type\":\"last\"},\"type\":\"query\"}],\"datasource\":{\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"B\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"refId\":\"C\",\"type\":\"threshold\"}"
     }
 
-    no_data_state  = "KeepLast"
+    no_data_state  = "OK"
     exec_err_state = "KeepLast"
     for            = "15m"
     annotations = {
@@ -307,7 +307,7 @@ resource "grafana_rule_group" "rule_group_52a0e1fab90ce868" {
       model          = "{\"conditions\":[{\"evaluator\":{\"params\":[10],\"type\":\"lt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[\"C\"]},\"reducer\":{\"params\":[],\"type\":\"last\"},\"type\":\"query\"}],\"datasource\":{\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"B\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"refId\":\"C\",\"type\":\"threshold\"}"
     }
 
-    no_data_state  = "KeepLast"
+    no_data_state  = "OK"
     exec_err_state = "Alerting"
     for            = "10m"
     annotations = {

--- a/terraform/alerts/Near/chain-signatures/multichain_loop_iterations.tf
+++ b/terraform/alerts/Near/chain-signatures/multichain_loop_iterations.tf
@@ -42,7 +42,7 @@ resource "grafana_rule_group" "rule_group_06a869a8aabfd2fb" {
       model          = "{\"conditions\":[{\"evaluator\":{\"params\":[50],\"type\":\"lt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[\"C\"]},\"reducer\":{\"params\":[],\"type\":\"last\"},\"type\":\"query\"}],\"datasource\":{\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"B\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"refId\":\"C\",\"type\":\"threshold\"}"
     }
 
-    no_data_state  = "NoData"
+    no_data_state  = "OK"
     exec_err_state = "Error"
     for            = "5m"
     annotations = {

--- a/terraform/alerts/Near/chain-signatures/prod_dashboard_alerts.tf
+++ b/terraform/alerts/Near/chain-signatures/prod_dashboard_alerts.tf
@@ -12,7 +12,7 @@ locals {
   business_critical_rules = [
     {
       name          = "[MAINNET][BUSINESS CRITICAL] In-time Requests SLI 30d below 95%"
-      expr          = "(sum(increase(multichain_sign_request_latency_sec_count{environment=\"mainnet\", step=\"total\", status=\"in_time\"}[30d])) / (sum(increase(multichain_sign_request_latency_sec_count{environment=\"mainnet\", step=\"total\", status=\"in_time\"}[30d])) + (sum(increase(multichain_sign_request_delayed{environment=\"mainnet\"}[30d])) or vector(0)))) * 100"
+      expr          = "(((((sum(increase(multichain_sign_request_latency_sec_count{environment=\"mainnet\", step=\"total\", status=\"in_time\"}[30d])) or vector(0)) + (sum(increase(multichain_sign_request_delayed{environment=\"mainnet\"}[30d])) or vector(0))) > bool 0) * ((((sum(increase(multichain_sign_request_latency_sec_count{environment=\"mainnet\", step=\"total\", status=\"in_time\"}[30d])) or vector(0)) / clamp_min((((sum(increase(multichain_sign_request_latency_sec_count{environment=\"mainnet\", step=\"total\", status=\"in_time\"}[30d])) or vector(0)) + (sum(increase(multichain_sign_request_delayed{environment=\"mainnet\"}[30d])) or vector(0))), 1)) * 100))) + (((((sum(increase(multichain_sign_request_latency_sec_count{environment=\"mainnet\", step=\"total\", status=\"in_time\"}[30d])) or vector(0)) + (sum(increase(multichain_sign_request_delayed{environment=\"mainnet\"}[30d])) or vector(0))) == bool 0) * 100))"
       threshold     = 95
       comparator    = "lt"
       panel_id      = "148"
@@ -22,7 +22,7 @@ locals {
       query_type    = "instant"
       range         = false
       instant       = true
-      no_data_state = "NoData"
+      no_data_state = "OK"
       summary       = "[MAINNET][BUSINESS CRITICAL] In-time requests SLI (30d) below 95%"
       description   = "Mainnet in-time requests SLI (30d) is below 95%: {{ $values.B }}"
     },
@@ -402,7 +402,7 @@ locals {
     },
     {
       name          = "[MAINNET][MPC] In-time Requests SLI Trend below 95%"
-      expr          = "(sum by(chain) (rate(multichain_sign_request_latency_sec_count{environment=\"mainnet\", step=\"total\", status=\"in_time\"}[$__rate_interval])) / (sum by(chain) (rate(multichain_sign_request_latency_sec_count{environment=\"mainnet\", step=\"total\", status=\"in_time\"}[$__rate_interval])) + (sum by(chain) (rate(multichain_sign_request_delayed{environment=\"mainnet\"}[$__rate_interval])) or (0 * sum by(chain) (rate(multichain_sign_request_latency_sec_count{environment=\"mainnet\", step=\"total\", status=\"in_time\"}[$__rate_interval])))))) * 100"
+      expr          = "(((((sum by(chain) (rate(multichain_sign_request_latency_sec_count{environment=\"mainnet\", step=\"total\", status=\"in_time\"}[$__rate_interval])) or vector(0)) + (sum by(chain) (rate(multichain_sign_request_delayed{environment=\"mainnet\"}[$__rate_interval])) or vector(0))) > bool 0) * ((((sum by(chain) (rate(multichain_sign_request_latency_sec_count{environment=\"mainnet\", step=\"total\", status=\"in_time\"}[$__rate_interval])) or vector(0)) / clamp_min((((sum by(chain) (rate(multichain_sign_request_latency_sec_count{environment=\"mainnet\", step=\"total\", status=\"in_time\"}[$__rate_interval])) or vector(0)) + (sum by(chain) (rate(multichain_sign_request_delayed{environment=\"mainnet\"}[$__rate_interval])) or vector(0))), 1)) * 100))) + (((((sum by(chain) (rate(multichain_sign_request_latency_sec_count{environment=\"mainnet\", step=\"total\", status=\"in_time\"}[$__rate_interval])) or vector(0)) + (sum by(chain) (rate(multichain_sign_request_delayed{environment=\"mainnet\"}[$__rate_interval])) or vector(0))) == bool 0) * 100))"
       threshold     = 95
       comparator    = "lt"
       panel_id      = "149"
@@ -412,7 +412,7 @@ locals {
       query_type    = "range"
       range         = true
       instant       = false
-      no_data_state = "NoData"
+      no_data_state = "OK"
       summary       = "[MAINNET][MPC] In-time requests SLI trend below 95%"
       description   = "Mainnet in-time requests SLI trend is below 95% for {{ $labels.chain }}: {{ $values.B }}%"
     },
@@ -444,7 +444,7 @@ locals {
       query_type    = "range"
       range         = true
       instant       = false
-      no_data_state = "NoData"
+      no_data_state = "OK"
       summary       = "[MAINNET][MPC] Backlog size above 200"
       description   = "Mainnet backlog size is above 200 for {{ $labels.node_account_id }}: {{ $values.B }}"
     },

--- a/terraform/alerts/Near/chain-signatures/success rates.tf
+++ b/terraform/alerts/Near/chain-signatures/success rates.tf
@@ -645,11 +645,21 @@ resource "grafana_rule_group" "rule_group_ab5e7f79a1339a71" {
         }
         editorMode    = "code"
         expr          = <<-EOT
-          sum by(node_account_id) (increase(multichain_num_total_historical_presignature_generators_success{environment="mainnet"}[1h]))
-          / sum by(node_account_id) (
-              increase(multichain_num_total_historical_presignature_generators_success{environment="mainnet"}[1h])
-              + (increase(multichain_presignature_generator_failures{environment="mainnet"}[1h]) or increase(multichain_num_total_historical_presignature_generators_success{environment="mainnet"}[1h]) * 0)
-            ) * 100
+          (
+            (((sum by(node_account_id) (increase(multichain_num_total_historical_presignature_generators_success{environment="mainnet"}[1h])) or vector(0))
+            + (sum by(node_account_id) (increase(multichain_presignature_generator_failures{environment="mainnet"}[1h])) or vector(0))) > bool 0)
+            * (
+              ((sum by(node_account_id) (increase(multichain_num_total_historical_presignature_generators_success{environment="mainnet"}[1h])) or vector(0))
+              / clamp_min(
+                ((sum by(node_account_id) (increase(multichain_num_total_historical_presignature_generators_success{environment="mainnet"}[1h])) or vector(0))
+                + (sum by(node_account_id) (increase(multichain_presignature_generator_failures{environment="mainnet"}[1h])) or vector(0))),
+                1
+              )) * 100
+            )
+          ) + (
+            (((sum by(node_account_id) (increase(multichain_num_total_historical_presignature_generators_success{environment="mainnet"}[1h])) or vector(0))
+            + (sum by(node_account_id) (increase(multichain_presignature_generator_failures{environment="mainnet"}[1h])) or vector(0))) == bool 0) * 100
+          )
         EOT
         instant       = false
         interval      = ""
@@ -738,7 +748,7 @@ resource "grafana_rule_group" "rule_group_ab5e7f79a1339a71" {
       })
     }
 
-    no_data_state  = "NoData"
+    no_data_state  = "OK"
     exec_err_state = "Error"
     for            = "1h"
     annotations = {
@@ -775,11 +785,21 @@ resource "grafana_rule_group" "rule_group_ab5e7f79a1339a71" {
         }
         editorMode    = "code"
         expr          = <<-EOT
-          sum by(node_account_id) (increase(multichain_num_total_historical_triple_generators_success{environment="mainnet"}[1h]))
-          / sum by(node_account_id) (
-              increase(multichain_num_total_historical_triple_generators_success{environment="mainnet"}[1h])
-              + (increase(multichain_triple_generator_failures{environment="mainnet"}[1h]) or increase(multichain_num_total_historical_triple_generators_success{environment="mainnet"}[1h]) * 0)
-            ) * 100
+          (
+            (((sum by(node_account_id) (increase(multichain_num_total_historical_triple_generators_success{environment="mainnet"}[1h])) or vector(0))
+            + (sum by(node_account_id) (increase(multichain_triple_generator_failures{environment="mainnet"}[1h])) or vector(0))) > bool 0)
+            * (
+              ((sum by(node_account_id) (increase(multichain_num_total_historical_triple_generators_success{environment="mainnet"}[1h])) or vector(0))
+              / clamp_min(
+                ((sum by(node_account_id) (increase(multichain_num_total_historical_triple_generators_success{environment="mainnet"}[1h])) or vector(0))
+                + (sum by(node_account_id) (increase(multichain_triple_generator_failures{environment="mainnet"}[1h])) or vector(0))),
+                1
+              )) * 100
+            )
+          ) + (
+            (((sum by(node_account_id) (increase(multichain_num_total_historical_triple_generators_success{environment="mainnet"}[1h])) or vector(0))
+            + (sum by(node_account_id) (increase(multichain_triple_generator_failures{environment="mainnet"}[1h])) or vector(0))) == bool 0) * 100
+          )
         EOT
         instant       = false
         interval      = ""
@@ -868,7 +888,7 @@ resource "grafana_rule_group" "rule_group_ab5e7f79a1339a71" {
       })
     }
 
-    no_data_state  = "NoData"
+    no_data_state  = "OK"
     exec_err_state = "Error"
     for            = "1h"
     annotations = {


### PR DESCRIPTION
## Summary
- suppress mainnet application alert no-data pages beyond the existing signature SLI fix
- return stable values for mainnet ratio alerts during zero-traffic windows instead of empty series
- keep SRE hardware and network no-data behavior unchanged so telemetry gaps still surface

## What changed
- set `no_data_state = "OK"` for the mainnet presignature and triple count alerts
- set `no_data_state = "OK"` for the mainnet loop-iterations alert and mainnet backlog alert
- rewrote the mainnet presignature and triple generator success-rate PromQL expressions so a zero-request window evaluates to `100`
- rewrote the mainnet business-critical 30d SLI expression and mainnet MPC SLI trend expression to avoid empty-series no-data paths on zero traffic

## Why
The current mainnet application alerts mix `KeepLast` and `NoData` with expressions that can still evaluate to empty series when traffic drops to zero or samples disappear. That leaves room for paging on no-data instead of a stable healthy result for application-level SLIs and counters.

This PR keeps that suppression scoped to app-level alerts. Hardware and network alerts still treat no data as a real signal because losing those metrics can indicate an observability or node outage.

## Verification
- `terraform -chdir=terraform/alerts/Near/chain-signatures fmt`
- `terraform -chdir=terraform/alerts/Near/chain-signatures init -backend=false -input=false`
- `terraform -chdir=terraform/alerts/Near/chain-signatures validate`
