### PR TITLE
fix(alerts): raise testnet signature success-rate threshold to 95%

### DIFF
--- a/terraform/alerts/Near/chain-signatures/success rates.tf
+++ b/terraform/alerts/Near/chain-signatures/success rates.tf
@@ -478,7 +478,7 @@ resource "grafana_rule_group" "rule_group_ab5e7f79a1339a71" {
       }
 
       datasource_uid = "__expr__"
-      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[40],\"type\":\"lt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[\"C\"]},\"reducer\":{\"params\":[],\"type\":\"last\"},\"type\":\"query\"}],\"datasource\":{\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"B\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"refId\":\"C\",\"type\":\"threshold\"}"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[95],\"type\":\"lt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[\"C\"]},\"reducer\":{\"params\":[],\"type\":\"last\"},\"type\":\"query\"}],\"datasource\":{\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"B\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"refId\":\"C\",\"type\":\"threshold\"}"
     }
 
     no_data_state  = "NoData"
@@ -487,8 +487,8 @@ resource "grafana_rule_group" "rule_group_ab5e7f79a1339a71" {
     annotations = {
       __dashboardUid__ = "a8258407-c08f-4796-9d3e-31caacde8653"
       __panelId__      = "149"
-      description      = "Solana 10-minute in-time request SLI has been below 40% for 5 minutes: {{ $values.A }}%"
-      summary          = "[TESTNET][SIGNATURES][SOLANA] Success rate below 40%"
+      description      = "Solana 10-minute in-time request SLI has been below 95% for 5 minutes: {{ $values.A }}%"
+      summary          = "[TESTNET][SIGNATURES][SOLANA] Success rate below 95%"
     }
     is_paused = false
 
@@ -552,7 +552,7 @@ resource "grafana_rule_group" "rule_group_ab5e7f79a1339a71" {
       }
 
       datasource_uid = "__expr__"
-      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[40],\"type\":\"lt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[\"C\"]},\"reducer\":{\"params\":[],\"type\":\"last\"},\"type\":\"query\"}],\"datasource\":{\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"B\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"refId\":\"C\",\"type\":\"threshold\"}"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[95],\"type\":\"lt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[\"C\"]},\"reducer\":{\"params\":[],\"type\":\"last\"},\"type\":\"query\"}],\"datasource\":{\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"B\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"refId\":\"C\",\"type\":\"threshold\"}"
     }
 
     no_data_state  = "NoData"
@@ -561,8 +561,8 @@ resource "grafana_rule_group" "rule_group_ab5e7f79a1339a71" {
     annotations = {
       __dashboardUid__ = "a8258407-c08f-4796-9d3e-31caacde8653"
       __panelId__      = "149"
-      description      = "Ethereum 10-minute in-time request SLI has been below 40% for 5 minutes: {{ $values.A }}%"
-      summary          = "[TESTNET][SIGNATURES][ETH] Success rate below 40%"
+      description      = "Ethereum 10-minute in-time request SLI has been below 95% for 5 minutes: {{ $values.A }}%"
+      summary          = "[TESTNET][SIGNATURES][ETH] Success rate below 95%"
     }
     is_paused = false
 


### PR DESCRIPTION
## Summary
- raise the Testnet Solana signature success-rate alert threshold from 40% to 95%
- raise the Testnet Ethereum signature success-rate alert threshold from 40% to 95%
- update alert summaries and descriptions to match the new threshold

## Testing
- inspected the resulting git diff
- ran terraform fmt on the edited file