### PR TITLE
feat(canton): add env-switchable monitoring dashboard

### DIFF
--- a/.github/workflows/deploy-cs-dashboards.yaml
+++ b/.github/workflows/deploy-cs-dashboards.yaml
@@ -18,6 +18,7 @@ jobs:
     outputs:
       balances: ${{ steps.filter.outputs.balances }}
       chain_signatures: ${{ steps.filter.outputs.chain_signatures }}
+      sre_canton_nodes: ${{ steps.filter.outputs.sre_canton_nodes }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -33,6 +34,8 @@ jobs:
               - 'terraform/dashboards/Near/balances/**'
             chain_signatures:
               - 'terraform/dashboards/Near/chain-signatures/**'
+            sre_canton_nodes:
+              - 'terraform/dashboards/SRE/canton-nodes/**'
 
   deploy-balances:
     name: Deploy balances dashboard
@@ -79,6 +82,42 @@ jobs:
       contents: read
     env:
       working-dir: ./terraform/dashboards/Near/chain-signatures
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.7.0
+
+      - name: Terraform init
+        run: terraform init -input=false
+        working-directory: ${{ env.working-dir }}
+        env:
+          GOOGLE_CREDENTIALS: ${{ secrets.GCP_STATE_SA }}
+
+      - name: Terraform plan
+        run: terraform plan -input=false
+        working-directory: ${{ env.working-dir }}
+        env:
+          GOOGLE_CREDENTIALS: ${{ secrets.GCP_STATE_SA }}
+
+      - name: Terraform apply
+        run: terraform apply -auto-approve -input=false
+        working-directory: ${{ env.working-dir }}
+        env:
+          GOOGLE_CREDENTIALS: ${{ secrets.GCP_STATE_SA }}
+
+  deploy-sre-canton-nodes:
+    name: Deploy SRE Canton Nodes dashboard
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.sre_canton_nodes == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      working-dir: ./terraform/dashboards/SRE/canton-nodes
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/terraform/dashboards/SRE/canton-nodes/canton_nodes.json
+++ b/terraform/dashboards/SRE/canton-nodes/canton_nodes.json
@@ -1,0 +1,1056 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Health",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "max by(app) (up{environment=\"$environment\", namespace=\"$namespace\", app=~\"$app\", pod=~\"$pod\"})",
+          "legendFormat": "{{app}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Scrape Targets Up",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "max(daml_health_status{environment=\"$environment\", namespace=\"$namespace\", app=\"participant\", component=\"participant\", pod=~\"$pod\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "Participant Health",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 99
+              },
+              {
+                "color": "green",
+                "value": 100
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "100 * min(daml_sequencer_client_sequencer_connection_pool_validated_connections{environment=\"$environment\", namespace=\"$namespace\", app=\"participant\", pod=~\"$pod\"}) / clamp_min(min(daml_sequencer_client_sequencer_connection_pool_trust_threshold{environment=\"$environment\", namespace=\"$namespace\", app=\"participant\", pod=~\"$pod\"}), 1)",
+          "refId": "A"
+        }
+      ],
+      "title": "Validated Connections / Trust Threshold",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "sum by(grpc_method_name, grpc_code) (rate(daml_grpc_server_handled_total{environment=\"$environment\", namespace=\"$namespace\", app=\"participant\", pod=~\"$pod\", grpc_code!=\"OK\"}[$__rate_interval]))",
+          "legendFormat": "{{grpc_method_name}} {{grpc_code}}",
+          "refId": "A"
+        }
+      ],
+      "title": "gRPC Non-OK Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "sum by(path, http_status) (rate(daml_http_requests_total{environment=\"$environment\", namespace=\"$namespace\", app=\"participant\", pod=~\"$pod\", http_status!~\"2..|101\"}[$__rate_interval]))",
+          "legendFormat": "{{path}} {{http_status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Non-Success Rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "id": 7,
+      "panels": [],
+      "title": "Pressure And Sync",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 17
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "100 * max(daml_participant_api_commands_max_in_flight_length{environment=\"$environment\", namespace=\"$namespace\", app=\"participant\", pod=~\"$pod\"}) / clamp_min(max(daml_participant_api_commands_max_in_flight_capacity{environment=\"$environment\", namespace=\"$namespace\", app=\"participant\", pod=~\"$pod\"}), 1)",
+          "legendFormat": "command capacity used",
+          "refId": "A"
+        }
+      ],
+      "title": "Command In-Flight Capacity Used",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 17
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "max(daml_participant_inflight_validation_requests{environment=\"$environment\", namespace=\"$namespace\", app=\"participant\", pod=~\"$pod\"})",
+          "legendFormat": "inflight validations",
+          "refId": "A"
+        }
+      ],
+      "title": "Inflight Validation Requests",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 17
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "max(daml_sequencer_client_handler_delay{environment=\"$environment\", namespace=\"$namespace\", app=\"participant\", pod=~\"$pod\"})",
+          "legendFormat": "handler delay",
+          "refId": "A"
+        }
+      ],
+      "title": "Sequencer Handler Delay",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 25
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "max(daml_sequencer_client_submissions_dropped{environment=\"$environment\", namespace=\"$namespace\", app=\"participant\", pod=~\"$pod\"})",
+          "legendFormat": "submissions dropped",
+          "refId": "A"
+        }
+      ],
+      "title": "Dropped Submissions",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 25
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "(max(splice_store_last_seen_record_time_ms{environment=\"$environment\", namespace=\"$namespace\", app=\"validator-app\", pod=~\"$pod\"}) - max(splice_store_last_ingested_record_time_ms{environment=\"$environment\", namespace=\"$namespace\", app=\"validator-app\", pod=~\"$pod\"})) / 1000",
+          "legendFormat": "ingestion lag",
+          "refId": "A"
+        }
+      ],
+      "title": "Validator Ingestion Lag",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 33
+      },
+      "id": 13,
+      "panels": [],
+      "title": "Latency And Resources",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 34
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "histogram_quantile(0.95, sum by(le, grpc_method_name) (rate(daml_grpc_server_duration_seconds_bucket{environment=\"$environment\", namespace=\"$namespace\", app=\"participant\", pod=~\"$pod\"}[$__rate_interval])))",
+          "legendFormat": "{{grpc_method_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "gRPC p95 Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 34
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "histogram_quantile(0.95, sum by(le) (rate(daml_db_query_duration_seconds_bucket{environment=\"$environment\", namespace=\"$namespace\", app=\"participant\", pod=~\"$pod\"}[$__rate_interval])))",
+          "legendFormat": "db query p95",
+          "refId": "A"
+        }
+      ],
+      "title": "DB Query p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 42
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "histogram_quantile(0.95, sum by(le, trigger_name) (rate(splice_trigger_latency_duration_seconds_bucket{environment=\"$environment\", namespace=\"$namespace\", app=\"validator-app\", pod=~\"$pod\"}[$__rate_interval])))",
+          "legendFormat": "{{trigger_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Trigger p95 Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 42
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "100 * sum by(app) (jvm_memory_used_bytes{environment=\"$environment\", namespace=\"$namespace\", app=~\"$app\", pod=~\"$pod\", jvm_memory_type=\"heap\"}) / clamp_min(sum by(app) (jvm_memory_limit_bytes{environment=\"$environment\", namespace=\"$namespace\", app=~\"$app\", pod=~\"$pod\", jvm_memory_type=\"heap\"}), 1)",
+          "legendFormat": "{{app}}",
+          "refId": "A"
+        }
+      ],
+      "title": "JVM Heap Used",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 50
+      },
+      "id": 18,
+      "panels": [],
+      "title": "Validator Business Signals",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 51
+      },
+      "id": 19,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "max(splice_wallet_unlocked_amulet_balance{environment=\"$environment\", namespace=\"$namespace\", app=\"validator-app\", pod=~\"$pod\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "Unlocked Amulet Balance",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 6,
+        "y": 51
+      },
+      "id": 20,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "max(splice_wallet_locked_amulet_balance{environment=\"$environment\", namespace=\"$namespace\", app=\"validator-app\", pod=~\"$pod\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "Locked Amulet Balance",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 51
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "sum by(trigger_name) (increase(splice_retries_failures{environment=\"$environment\", namespace=\"$namespace\", app=\"validator-app\", pod=~\"$pod\"}[$__rate_interval]))",
+          "legendFormat": "{{trigger_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Retry Failure Increases",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "1m",
+  "schemaVersion": 42,
+  "tags": [
+    "canton",
+    "sre"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "dev",
+          "value": "dev"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "grafanacloud-prom"
+        },
+        "definition": "label_values(up{namespace=\"canton-validator\"}, environment)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Environment",
+        "multi": false,
+        "name": "environment",
+        "options": [],
+        "query": {
+          "query": "label_values(up{namespace=\"canton-validator\"}, environment)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "/^(dev|testnet|mainnet)$/",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "canton-validator",
+          "value": "canton-validator"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "label": "Namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [
+          {
+            "selected": true,
+            "text": "canton-validator",
+            "value": "canton-validator"
+          }
+        ],
+        "query": "canton-validator",
+        "type": "custom"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "grafanacloud-prom"
+        },
+        "definition": "label_values(up{environment=\"$environment\", namespace=\"$namespace\"}, app)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "App",
+        "multi": true,
+        "name": "app",
+        "options": [],
+        "query": {
+          "query": "label_values(up{environment=\"$environment\", namespace=\"$namespace\"}, app)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "grafanacloud-prom"
+        },
+        "definition": "label_values(up{environment=\"$environment\", namespace=\"$namespace\", app=~\"$app\"}, pod)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Pod",
+        "multi": true,
+        "name": "pod",
+        "options": [],
+        "query": {
+          "query": "label_values(up{environment=\"$environment\", namespace=\"$namespace\", app=~\"$app\"}, pod)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Canton Nodes",
+  "uid": "canton-nodes",
+  "version": 1,
+  "weekStart": ""
+}

--- a/terraform/dashboards/SRE/canton-nodes/main.tf
+++ b/terraform/dashboards/SRE/canton-nodes/main.tf
@@ -1,0 +1,9 @@
+resource "grafana_folder" "sre" {
+  title = "SRE"
+  uid   = "sre"
+}
+
+resource "grafana_dashboard" "canton_nodes" {
+  folder      = grafana_folder.sre.uid
+  config_json = file("${path.module}/canton_nodes.json")
+}

--- a/terraform/dashboards/SRE/canton-nodes/outputs.tf
+++ b/terraform/dashboards/SRE/canton-nodes/outputs.tf
@@ -1,0 +1,7 @@
+output "folder_uid" {
+  value = grafana_folder.sre.uid
+}
+
+output "dashboard_uid" {
+  value = grafana_dashboard.canton_nodes.uid
+}

--- a/terraform/dashboards/SRE/canton-nodes/resources.tf
+++ b/terraform/dashboards/SRE/canton-nodes/resources.tf
@@ -1,0 +1,29 @@
+terraform {
+  backend "gcs" {
+    bucket = "sig-infra-terraform"
+    prefix = "terraform/grafana/dashboards/sre/canton-nodes"
+  }
+
+  required_providers {
+    grafana = {
+      source  = "grafana/grafana"
+      version = "4.36.0"
+    }
+  }
+}
+
+provider "grafana" {
+  url  = data.google_secret_manager_secret_version.grafana_cloud_url.secret_data
+  auth = data.google_secret_manager_secret_version.dashboard_token.secret_data
+}
+
+data "google_secret_manager_secret_version" "dashboard_token" {
+  project = "sig-bootstrap"
+  secret  = "grafana_cloud_dashboards_token"
+  version = "2"
+}
+
+data "google_secret_manager_secret_version" "grafana_cloud_url" {
+  project = "sig-bootstrap"
+  secret  = "grafana-cloud-url"
+}


### PR DESCRIPTION
## Summary
- add a new Canton Nodes dashboard under the SRE folder
- add an environment variable so the same dashboard can switch between dev, testnet, and mainnet
- cover scrape health, participant health, gRPC and HTTP errors, command pressure, sequencer connectivity and delay, dropped submissions, validator ingestion lag, latency panels, JVM heap, retry failures, and wallet balances

## Validation
- `jq empty terraform/dashboards/SRE/canton-nodes/canton_nodes.json`
- `terraform -chdir=terraform/dashboards/SRE/canton-nodes init -backend=false`
- `terraform -chdir=terraform/dashboards/SRE/canton-nodes validate`