### PR TITLE
feat(sre): import hardware dashboards and alerts

### DIFF
--- a/.github/workflows/deploy-alerts.yaml
+++ b/.github/workflows/deploy-alerts.yaml
@@ -18,6 +18,7 @@ jobs:
     outputs:
       chain_signatures: ${{ steps.filter.outputs.chain_signatures }}
       mpc_recovery: ${{ steps.filter.outputs.mpc_recovery }}
+      sre_node_hardware: ${{ steps.filter.outputs.sre_node_hardware }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -33,6 +34,8 @@ jobs:
               - 'terraform/alerts/Near/chain-signatures/**'
             mpc_recovery:
               - 'terraform/alerts/Near/mpc-recovery/**'
+            sre_node_hardware:
+              - 'terraform/alerts/SRE/node-hardware/**'
 
   deploy-chain-signatures:
     name: Deploy chain-signatures alerts
@@ -79,6 +82,42 @@ jobs:
       contents: read
     env:
       working-dir: ./terraform/alerts/Near/mpc-recovery
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.7.0
+
+      - name: Terraform init
+        run: terraform init -input=false
+        working-directory: ${{ env.working-dir }}
+        env:
+          GOOGLE_CREDENTIALS: ${{ secrets.GCP_STATE_SA }}
+
+      - name: Terraform plan
+        run: terraform plan -input=false
+        working-directory: ${{ env.working-dir }}
+        env:
+          GOOGLE_CREDENTIALS: ${{ secrets.GCP_STATE_SA }}
+
+      - name: Terraform apply
+        run: terraform apply -auto-approve -input=false
+        working-directory: ${{ env.working-dir }}
+        env:
+          GOOGLE_CREDENTIALS: ${{ secrets.GCP_STATE_SA }}
+
+  deploy-sre-node-hardware:
+    name: Deploy SRE node hardware alerts
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.sre_node_hardware == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      working-dir: ./terraform/alerts/SRE/node-hardware
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-cs-dashboards.yaml
+++ b/.github/workflows/deploy-cs-dashboards.yaml
@@ -19,6 +19,7 @@ jobs:
       balances: ${{ steps.filter.outputs.balances }}
       chain_signatures: ${{ steps.filter.outputs.chain_signatures }}
       sre_canton_nodes: ${{ steps.filter.outputs.sre_canton_nodes }}
+      sre_node_hardware: ${{ steps.filter.outputs.sre_node_hardware }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -36,6 +37,8 @@ jobs:
               - 'terraform/dashboards/Near/chain-signatures/**'
             sre_canton_nodes:
               - 'terraform/dashboards/SRE/canton-nodes/**'
+            sre_node_hardware:
+              - 'terraform/dashboards/SRE/node-hardware/**'
 
   deploy-balances:
     name: Deploy balances dashboard
@@ -118,6 +121,42 @@ jobs:
       contents: read
     env:
       working-dir: ./terraform/dashboards/SRE/canton-nodes
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.7.0
+
+      - name: Terraform init
+        run: terraform init -input=false
+        working-directory: ${{ env.working-dir }}
+        env:
+          GOOGLE_CREDENTIALS: ${{ secrets.GCP_STATE_SA }}
+
+      - name: Terraform plan
+        run: terraform plan -input=false
+        working-directory: ${{ env.working-dir }}
+        env:
+          GOOGLE_CREDENTIALS: ${{ secrets.GCP_STATE_SA }}
+
+      - name: Terraform apply
+        run: terraform apply -auto-approve -input=false
+        working-directory: ${{ env.working-dir }}
+        env:
+          GOOGLE_CREDENTIALS: ${{ secrets.GCP_STATE_SA }}
+
+  deploy-sre-node-hardware:
+    name: Deploy SRE node hardware dashboards
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.sre_node_hardware == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      working-dir: ./terraform/dashboards/SRE/node-hardware
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/terraform/alerts/SRE/node-hardware/hardware_metrics.tf
+++ b/terraform/alerts/SRE/node-hardware/hardware_metrics.tf
@@ -1,0 +1,1375 @@
+resource "grafana_rule_group" "sre_node_hardware" {
+  org_id           = 1
+  name             = "CPU Usage"
+  folder_uid       = "befk4ud4xv5s0d"
+  interval_seconds = 60
+
+  rule {
+    name      = "Multichain Mainnet Node CPU usage"
+    condition = "G"
+
+    data {
+      ref_id     = "A"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 10800
+        to   = 0
+      }
+
+      datasource_uid = "aefk7aww1brb4c"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"aefk7aww1brb4c\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\\\"k8s_container\\\",project_id=\\\"near-cs-mainnet\\\",location=\\\"europe-west1\\\",cluster_name=\\\"mainnet\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-mainnet-0\\\"}[1s]))\",\"projectName\":\"near-cs-mainnet\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"A\",\"timeSeriesList\":{\"alignmentPeriod\":\"cloud-monitoring-auto\",\"crossSeriesReducer\":\"REDUCE_NONE\",\"filters\":[\"metric.type\",\"=\",\"kubernetes.io/anthos/APIServiceOpenAPIAggregationControllerQueue1_longest_running_processor_microseconds\"],\"groupBys\":[],\"perSeriesAligner\":\"ALIGN_NONE\",\"preprocessor\":\"none\",\"projectName\":\"near-cs-mainnet\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "B"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 10800
+        to   = 0
+      }
+
+      datasource_uid = "aefk7aww1brb4c"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"aefk7aww1brb4c\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(avg_over_time(kubernetes_io:container_cpu_limit_cores{monitored_resource=\\\"k8s_container\\\",project_id=\\\"near-cs-mainnet\\\",location=\\\"europe-west1\\\",cluster_name=\\\"mainnet\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-mainnet-0\\\"}[3h]))\",\"projectName\":\"near-cs-mainnet\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"B\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-mainnet\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id = "C"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[\"C\"]},\"reducer\":{\"params\":[],\"type\":\"last\"},\"type\":\"query\"}],\"datasource\":{\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"A\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"C\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "D"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[\"D\"]},\"reducer\":{\"params\":[],\"type\":\"last\"},\"type\":\"query\"}],\"datasource\":{\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"C\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"refId\":\"D\",\"type\":\"threshold\"}"
+    }
+    data {
+      ref_id = "E"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"B\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"E\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "F"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"$${C}/$${E} > 0.8\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"refId\":\"F\",\"type\":\"math\"}"
+    }
+    data {
+      ref_id = "G"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\",\"unloadEvaluator\":{\"params\":[0,0],\"type\":\"lt\"}}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"F\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"refId\":\"G\",\"type\":\"threshold\"}"
+    }
+
+    no_data_state  = "NoData"
+    exec_err_state = "Error"
+    for            = "1h"
+    annotations = {
+      __dashboardUid__ = "defk916x2e0hsd"
+      __panelId__      = "1"
+      description      = "Check CPU usage of mainnet node, reduce limit if an error, or scale accordingly"
+      summary          = "[MAINNET] CPU USAGE HIGH FOR 1H"
+    }
+    is_paused = false
+
+    notification_settings {
+      contact_point = "SRE On-call"
+    }
+  }
+  rule {
+    name      = "Mainnet Node Memory"
+    condition = "D"
+
+    data {
+      ref_id     = "A"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 10800
+        to   = 0
+      }
+
+      datasource_uid = "aefk7aww1brb4c"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"aefk7aww1brb4c\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\\\"k8s_container\\\",memory_type=\\\"non-evictable\\\",project_id=\\\"near-cs-mainnet\\\",location=\\\"europe-west1\\\",cluster_name=\\\"mainnet\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-mainnet-0\\\"}[30m]))\",\"projectName\":\"near-cs-mainnet\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"A\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-mainnet\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "B"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 10800
+        to   = 0
+      }
+
+      datasource_uid = "aefk7aww1brb4c"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"aefk7aww1brb4c\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(avg_over_time(kubernetes_io:container_memory_limit_bytes{monitored_resource=\\\"k8s_container\\\",project_id=\\\"near-cs-mainnet\\\",location=\\\"europe-west1\\\",cluster_name=\\\"mainnet\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-mainnet-0\\\"}[3h]))\",\"projectName\":\"near-cs-mainnet\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"B\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-mainnet\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id = "C"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[\"C\"]},\"reducer\":{\"params\":[],\"type\":\"last\"},\"type\":\"query\"}],\"datasource\":{\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"A\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"C\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "D"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[\"D\"]},\"reducer\":{\"params\":[],\"type\":\"last\"},\"type\":\"query\"}],\"datasource\":{\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"F\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"refId\":\"D\",\"type\":\"threshold\"}"
+    }
+    data {
+      ref_id = "E"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"B\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"E\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "F"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"$${C}/$${E} > 0.80\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"refId\":\"F\",\"type\":\"math\"}"
+    }
+
+    no_data_state  = "NoData"
+    exec_err_state = "Error"
+    for            = "1m"
+    annotations = {
+      __dashboardUid__ = "defk916x2e0hsd"
+      __panelId__      = "2"
+      description      = "Check mainnet node memory, if error, set lower limit to reduce costs, otherwise scale accordingly"
+      summary          = "[MAINNET]Memory Usage High on node"
+    }
+    labels    = {}
+    is_paused = false
+
+    notification_settings {
+      contact_point = "SRE On-call"
+    }
+  }
+  rule {
+    name      = "Dev Node CPU Metrics"
+    condition = "O"
+
+    data {
+      ref_id     = "A"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 21600
+        to   = 0
+      }
+
+      datasource_uid = "eefmhllfyfjswe"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"eefmhllfyfjswe\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\\\"k8s_container\\\",project_id=\\\"near-cs-dev\\\",location=\\\"europe-west1\\\",cluster_name=\\\"dev\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-dev-0\\\"}[1s]))\",\"projectName\":\"near-cs-dev\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"A\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-dev\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "B"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 21600
+        to   = 0
+      }
+
+      datasource_uid = "eefmhllfyfjswe"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"eefmhllfyfjswe\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\\\"k8s_container\\\",project_id=\\\"near-cs-dev\\\",location=\\\"europe-west1\\\",cluster_name=\\\"dev\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-dev-1\\\"}[1s]))\",\"projectName\":\"near-cs-dev\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"B\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-dev\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "C"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 21600
+        to   = 0
+      }
+
+      datasource_uid = "eefmhllfyfjswe"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"eefmhllfyfjswe\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\\\"k8s_container\\\",project_id=\\\"near-cs-dev\\\",location=\\\"europe-west1\\\",cluster_name=\\\"dev\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-dev-2\\\"}[1s]))\",\"projectName\":\"near-cs-dev\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"C\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-dev\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "D"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 21600
+        to   = 0
+      }
+
+      datasource_uid = "eefmhllfyfjswe"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"eefmhllfyfjswe\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\\\"k8s_container\\\",project_id=\\\"near-cs-dev\\\",location=\\\"europe-west1\\\",cluster_name=\\\"dev\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-dev-3\\\"}[1s]))\",\"projectName\":\"near-cs-dev\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"D\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-dev\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "E"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 21600
+        to   = 0
+      }
+
+      datasource_uid = "eefmhllfyfjswe"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"eefmhllfyfjswe\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\\\"k8s_container\\\",project_id=\\\"near-cs-dev\\\",location=\\\"europe-west1\\\",cluster_name=\\\"dev\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-dev-4\\\"}[1s]))\",\"projectName\":\"near-cs-dev\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"E\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-dev\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "F"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 21600
+        to   = 0
+      }
+
+      datasource_uid = "eefmhllfyfjswe"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"eefmhllfyfjswe\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\\\"k8s_container\\\",project_id=\\\"near-cs-dev\\\",location=\\\"europe-west1\\\",cluster_name=\\\"dev\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-dev-5\\\"}[1s]))\",\"projectName\":\"near-cs-dev\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"F\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-dev\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "G"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 21600
+        to   = 0
+      }
+
+      datasource_uid = "eefmhllfyfjswe"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"eefmhllfyfjswe\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\\\"k8s_container\\\",project_id=\\\"near-cs-dev\\\",location=\\\"europe-west1\\\",cluster_name=\\\"dev\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-dev-6\\\"}[1s]))\",\"projectName\":\"near-cs-dev\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"G\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-dev\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "H"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 21600
+        to   = 0
+      }
+
+      datasource_uid = "eefmhllfyfjswe"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"eefmhllfyfjswe\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\\\"k8s_container\\\",project_id=\\\"near-cs-dev\\\",location=\\\"europe-west1\\\",cluster_name=\\\"dev\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-dev-7\\\"}[1s]))\",\"projectName\":\"near-cs-dev\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"H\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-dev\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "I"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 21600
+        to   = 0
+      }
+
+      datasource_uid = "eefmhllfyfjswe"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"eefmhllfyfjswe\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\\\"k8s_container\\\",project_id=\\\"near-cs-dev\\\",location=\\\"europe-west1\\\",cluster_name=\\\"dev\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-dev-8\\\"}[1s]))\",\"projectName\":\"near-cs-dev\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"I\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-dev\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "J"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 21600
+        to   = 0
+      }
+
+      datasource_uid = "eefmhllfyfjswe"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"eefmhllfyfjswe\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\\\"k8s_container\\\",project_id=\\\"near-cs-dev\\\",location=\\\"europe-west1\\\",cluster_name=\\\"dev\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-dev-9\\\"}[1s]))\",\"projectName\":\"near-cs-dev\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"J\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-dev\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "K"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 21600
+        to   = 0
+      }
+
+      datasource_uid = "eefmhllfyfjswe"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"eefmhllfyfjswe\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\\\"k8s_container\\\",project_id=\\\"near-cs-dev\\\",location=\\\"europe-west1\\\",cluster_name=\\\"dev\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-dev-10\\\"}[1s]))\",\"projectName\":\"near-cs-dev\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"K\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-dev\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "L"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 21600
+        to   = 0
+      }
+
+      datasource_uid = "eefmhllfyfjswe"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"eefmhllfyfjswe\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\\\"k8s_container\\\",project_id=\\\"near-cs-dev\\\",location=\\\"europe-west1\\\",cluster_name=\\\"dev\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-dev-11\\\"}[1s]))\",\"projectName\":\"near-cs-dev\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"L\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-dev\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "M"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 21600
+        to   = 0
+      }
+
+      datasource_uid = "eefmhllfyfjswe"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"eefmhllfyfjswe\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(avg_over_time(kubernetes_io:container_cpu_limit_cores{monitored_resource=\\\"k8s_container\\\",project_id=\\\"near-cs-dev\\\",location=\\\"europe-west1\\\",cluster_name=\\\"dev\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-dev-0\\\"}[3h]))\",\"projectName\":\"near-cs-dev\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"M\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-dev\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id = "N"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[\"N\"]},\"reducer\":{\"params\":[],\"type\":\"last\"},\"type\":\"query\"}],\"datasource\":{\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"A\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"N\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "O"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[\"O\"]},\"reducer\":{\"params\":[],\"type\":\"last\"},\"type\":\"query\"}],\"datasource\":{\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"P\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"refId\":\"O\",\"type\":\"threshold\"}"
+    }
+    data {
+      ref_id = "P"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"$N/$AB > 0.8 ||\\n$Q/$AB > 0.8 ||\\n$R/$AB > 0.8 ||\\n$S/$AB > 0.8 ||\\n$T/$AB > 0.8 ||\\n$U/$AB > 0.8 ||\\n$V/$AB > 0.8 ||\\n$W/$AB > 0.8 ||\\n$X/$AB > 0.8 ||\\n$Y/$AB > 0.8 ||\\n$Z/$AB > 0.8 ||\\n$AA/$AB > 0.8\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"refId\":\"P\",\"type\":\"math\"}"
+    }
+    data {
+      ref_id = "Q"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"B\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"Q\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "R"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"C\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"R\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "S"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"D\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"S\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "T"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"E\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"T\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "U"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"F\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"U\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "V"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"G\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"V\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "W"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"H\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"W\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "X"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"I\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"X\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "Y"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"J\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"Y\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "Z"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"K\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"Z\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "AA"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"L\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"AA\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "AB"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"M\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"AB\",\"type\":\"reduce\"}"
+    }
+
+    no_data_state  = "OK"
+    exec_err_state = "OK"
+    for            = "1h"
+    annotations = {
+      __dashboardUid__ = "aefmio30pt3i8e"
+      __panelId__      = "1"
+      description      = "Check Dev nodes and decrease CPU limits if error, or scale as needed if increased traffic."
+      summary          = "[DEV]CPU USAGE HIGH FOR 1H"
+    }
+    is_paused = false
+
+    notification_settings {
+      contact_point = "SRE On-call"
+    }
+  }
+  rule {
+    name      = "Dev Node Memory Metrics"
+    condition = "O"
+
+    data {
+      ref_id     = "A"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 21600
+        to   = 0
+      }
+
+      datasource_uid = "eefmhllfyfjswe"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"eefmhllfyfjswe\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\\\"k8s_container\\\",memory_type=\\\"non-evictable\\\",project_id=\\\"near-cs-dev\\\",location=\\\"europe-west1\\\",cluster_name=\\\"dev\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-dev-0\\\"}[30s]))\",\"projectName\":\"near-cs-dev\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"A\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-dev\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "B"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 21600
+        to   = 0
+      }
+
+      datasource_uid = "eefmhllfyfjswe"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"eefmhllfyfjswe\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\\\"k8s_container\\\",memory_type=\\\"non-evictable\\\",project_id=\\\"near-cs-dev\\\",location=\\\"europe-west1\\\",cluster_name=\\\"dev\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-dev-1\\\"}[30s]))\",\"projectName\":\"near-cs-dev\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"B\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-dev\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "C"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 21600
+        to   = 0
+      }
+
+      datasource_uid = "eefmhllfyfjswe"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"eefmhllfyfjswe\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\\\"k8s_container\\\",memory_type=\\\"non-evictable\\\",project_id=\\\"near-cs-dev\\\",location=\\\"europe-west1\\\",cluster_name=\\\"dev\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-dev-2\\\"}[30s]))\",\"projectName\":\"near-cs-dev\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"C\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-dev\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "D"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 21600
+        to   = 0
+      }
+
+      datasource_uid = "eefmhllfyfjswe"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"eefmhllfyfjswe\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\\\"k8s_container\\\",memory_type=\\\"non-evictable\\\",project_id=\\\"near-cs-dev\\\",location=\\\"europe-west1\\\",cluster_name=\\\"dev\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-dev-3\\\"}[30s]))\",\"projectName\":\"near-cs-dev\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"D\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-dev\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "E"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 21600
+        to   = 0
+      }
+
+      datasource_uid = "eefmhllfyfjswe"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"eefmhllfyfjswe\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\\\"k8s_container\\\",memory_type=\\\"non-evictable\\\",project_id=\\\"near-cs-dev\\\",location=\\\"europe-west1\\\",cluster_name=\\\"dev\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-dev-4\\\"}[30s]))\",\"projectName\":\"near-cs-dev\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"E\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-dev\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "F"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 21600
+        to   = 0
+      }
+
+      datasource_uid = "eefmhllfyfjswe"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"eefmhllfyfjswe\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\\\"k8s_container\\\",memory_type=\\\"non-evictable\\\",project_id=\\\"near-cs-dev\\\",location=\\\"europe-west1\\\",cluster_name=\\\"dev\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-dev-5\\\"}[30s]))\",\"projectName\":\"near-cs-dev\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"F\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-dev\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "G"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 21600
+        to   = 0
+      }
+
+      datasource_uid = "eefmhllfyfjswe"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"eefmhllfyfjswe\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\\\"k8s_container\\\",memory_type=\\\"non-evictable\\\",project_id=\\\"near-cs-dev\\\",location=\\\"europe-west1\\\",cluster_name=\\\"dev\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-dev-6\\\"}[30s]))\",\"projectName\":\"near-cs-dev\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"G\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-dev\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "H"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 21600
+        to   = 0
+      }
+
+      datasource_uid = "eefmhllfyfjswe"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"eefmhllfyfjswe\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\\\"k8s_container\\\",memory_type=\\\"non-evictable\\\",project_id=\\\"near-cs-dev\\\",location=\\\"europe-west1\\\",cluster_name=\\\"dev\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-dev-7\\\"}[30s]))\",\"projectName\":\"near-cs-dev\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"H\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-dev\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "I"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 21600
+        to   = 0
+      }
+
+      datasource_uid = "eefmhllfyfjswe"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"eefmhllfyfjswe\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\\\"k8s_container\\\",memory_type=\\\"non-evictable\\\",project_id=\\\"near-cs-dev\\\",location=\\\"europe-west1\\\",cluster_name=\\\"dev\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-dev-8\\\"}[30s]))\",\"projectName\":\"near-cs-dev\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"I\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-dev\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "J"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 21600
+        to   = 0
+      }
+
+      datasource_uid = "eefmhllfyfjswe"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"eefmhllfyfjswe\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\\\"k8s_container\\\",memory_type=\\\"non-evictable\\\",project_id=\\\"near-cs-dev\\\",location=\\\"europe-west1\\\",cluster_name=\\\"dev\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-dev-9\\\"}[30s]))\",\"projectName\":\"near-cs-dev\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"J\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-dev\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "K"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 21600
+        to   = 0
+      }
+
+      datasource_uid = "eefmhllfyfjswe"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"eefmhllfyfjswe\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\\\"k8s_container\\\",memory_type=\\\"non-evictable\\\",project_id=\\\"near-cs-dev\\\",location=\\\"europe-west1\\\",cluster_name=\\\"dev\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-dev-10\\\"}[30s]))\",\"projectName\":\"near-cs-dev\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"K\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-dev\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "L"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 21600
+        to   = 0
+      }
+
+      datasource_uid = "eefmhllfyfjswe"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"eefmhllfyfjswe\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\\\"k8s_container\\\",memory_type=\\\"non-evictable\\\",project_id=\\\"near-cs-dev\\\",location=\\\"europe-west1\\\",cluster_name=\\\"dev\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-dev-11\\\"}[30s]))\",\"projectName\":\"near-cs-dev\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"L\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-dev\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "M"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 21600
+        to   = 0
+      }
+
+      datasource_uid = "eefmhllfyfjswe"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"eefmhllfyfjswe\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(avg_over_time(kubernetes_io:container_memory_limit_bytes{monitored_resource=\\\"k8s_container\\\",project_id=\\\"near-cs-dev\\\",location=\\\"europe-west1\\\",cluster_name=\\\"dev\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-dev-0\\\"}[3h]))\",\"projectName\":\"near-cs-dev\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"M\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-dev\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id = "N"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[\"N\"]},\"reducer\":{\"params\":[],\"type\":\"last\"},\"type\":\"query\"}],\"datasource\":{\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"A\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"N\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "O"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[\"O\"]},\"reducer\":{\"params\":[],\"type\":\"last\"},\"type\":\"query\"}],\"datasource\":{\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"P\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"refId\":\"O\",\"type\":\"threshold\"}"
+    }
+    data {
+      ref_id = "P"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"$N / $AB > 0.8 ||\\n$Q / $AB > 0.8 ||\\n$R / $AB > 0.8 ||\\n$S / $AB > 0.8 ||\\n$T / $AB > 0.8 ||\\n$U / $AB > 0.8 ||\\n$V / $AB > 0.8 ||\\n$W / $AB > 0.8 ||\\n$X / $AB > 0.8 ||\\n$Y / $AB > 0.8 ||\\n$Z / $AB > 0.8 ||\\n$AA / $AB > 0.8\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"refId\":\"P\",\"type\":\"math\"}"
+    }
+    data {
+      ref_id = "Q"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"B\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"Q\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "R"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"C\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"R\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "S"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"D\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"S\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "T"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"E\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"T\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "U"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"F\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"U\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "V"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"G\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"V\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "W"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"H\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"W\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "X"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"I\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"X\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "Y"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"J\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"Y\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "Z"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"K\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"Z\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "AA"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"L\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"AA\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "AB"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"M\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"AB\",\"type\":\"reduce\"}"
+    }
+
+    no_data_state  = "OK"
+    exec_err_state = "OK"
+    for            = "1m"
+    annotations = {
+      __dashboardUid__ = "aefmio30pt3i8e"
+      __panelId__      = "2"
+      description      = "Check Dev nodes for high mem usage, if error reduce limits further, if high traffic scale accordingly"
+      summary          = "[DEV]DEV NODE MEMORY USAGE HIGH"
+    }
+    is_paused = false
+
+    notification_settings {
+      contact_point = "SRE On-call"
+    }
+  }
+  rule {
+    name      = "Testnet Node CPU Metrics"
+    condition = "K"
+
+    data {
+      ref_id     = "A"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 10800
+        to   = 0
+      }
+
+      datasource_uid = "cefmhlk39et4wb"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"cefmhlk39et4wb\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\\\"k8s_container\\\",project_id=\\\"near-cs-testnet\\\",location=\\\"europe-west1\\\",cluster_name=\\\"testnet\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-testnet-0\\\"}[1s]))\",\"projectName\":\"near-cs-testnet\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"A\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-testnet\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "B"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 10800
+        to   = 0
+      }
+
+      datasource_uid = "cefmhlk39et4wb"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"cefmhlk39et4wb\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\\\"k8s_container\\\",project_id=\\\"near-cs-testnet\\\",location=\\\"europe-west1\\\",cluster_name=\\\"testnet\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-testnet-1\\\"}[1s]))\",\"projectName\":\"near-cs-testnet\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"B\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-testnet\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "C"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 10800
+        to   = 0
+      }
+
+      datasource_uid = "cefmhlk39et4wb"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"cefmhlk39et4wb\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\\\"k8s_container\\\",project_id=\\\"near-cs-testnet\\\",location=\\\"europe-west1\\\",cluster_name=\\\"testnet\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-testnet-2\\\"}[1s]))\",\"projectName\":\"near-cs-testnet\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"C\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-testnet\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "D"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 10800
+        to   = 0
+      }
+
+      datasource_uid = "cefmhlk39et4wb"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"cefmhlk39et4wb\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\\\"k8s_container\\\",project_id=\\\"near-cs-testnet\\\",location=\\\"europe-west1\\\",cluster_name=\\\"testnet\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-testnet-3\\\"}[1s]))\",\"projectName\":\"near-cs-testnet\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"D\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-testnet\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "E"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 10800
+        to   = 0
+      }
+
+      datasource_uid = "cefmhlk39et4wb"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"cefmhlk39et4wb\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\\\"k8s_container\\\",project_id=\\\"near-cs-testnet\\\",location=\\\"europe-west1\\\",cluster_name=\\\"testnet\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-testnet-4\\\"}[1s]))\",\"projectName\":\"near-cs-testnet\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"E\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-testnet\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "F"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 10800
+        to   = 0
+      }
+
+      datasource_uid = "cefmhlk39et4wb"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"cefmhlk39et4wb\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\\\"k8s_container\\\",project_id=\\\"near-cs-testnet\\\",location=\\\"europe-west1\\\",cluster_name=\\\"testnet\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-testnet-5\\\"}[1s]))\",\"projectName\":\"near-cs-testnet\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"F\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-testnet\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "G"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 10800
+        to   = 0
+      }
+
+      datasource_uid = "cefmhlk39et4wb"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"cefmhlk39et4wb\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\\\"k8s_container\\\",project_id=\\\"near-cs-testnet\\\",location=\\\"europe-west1\\\",cluster_name=\\\"testnet\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-testnet-6\\\"}[1s]))\",\"projectName\":\"near-cs-testnet\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"G\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-testnet\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "H"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 10800
+        to   = 0
+      }
+
+      datasource_uid = "cefmhlk39et4wb"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"cefmhlk39et4wb\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\\\"k8s_container\\\",project_id=\\\"near-cs-testnet\\\",location=\\\"europe-west1\\\",cluster_name=\\\"testnet\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-testnet-7\\\"}[1s]))\",\"projectName\":\"near-cs-testnet\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"H\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-testnet\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "I"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 10800
+        to   = 0
+      }
+
+      datasource_uid = "cefmhlk39et4wb"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"cefmhlk39et4wb\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(avg_over_time(kubernetes_io:container_cpu_limit_cores{monitored_resource=\\\"k8s_container\\\",project_id=\\\"near-cs-testnet\\\",location=\\\"europe-west1\\\",cluster_name=\\\"testnet\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-testnet-0\\\"}[3h]))\",\"projectName\":\"near-cs-testnet\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"I\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-testnet\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id = "J"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[\"J\"]},\"reducer\":{\"params\":[],\"type\":\"last\"},\"type\":\"query\"}],\"datasource\":{\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"A\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"J\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "K"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[\"K\"]},\"reducer\":{\"params\":[],\"type\":\"last\"},\"type\":\"query\"}],\"datasource\":{\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"T\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"refId\":\"K\",\"type\":\"threshold\"}"
+    }
+    data {
+      ref_id = "L"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"I\",\"hide\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"L\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "M"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"B\",\"hide\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"M\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "N"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"C\",\"hide\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"N\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "O"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"D\",\"hide\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"O\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "P"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"E\",\"hide\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"P\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "Q"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"F\",\"hide\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"Q\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "R"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"G\",\"hide\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"R\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "S"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"H\",\"hide\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"S\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "T"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"$J/$L > 0.8 ||\\n$M/$L > 0.8 ||\\n$N/$L > 0.8 ||\\n$O/$L > 0.8 ||\\n$P/$L > 0.8 ||\\n$Q/$L > 0.8 ||\\n$R/$L > 0.8 ||\\n$S/$L > 0.8\",\"hide\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"refId\":\"T\",\"type\":\"math\"}"
+    }
+
+    no_data_state  = "NoData"
+    exec_err_state = "Error"
+    for            = "1h"
+    annotations = {
+      __dashboardUid__ = "cefmotn3trs3ke"
+      __panelId__      = "1"
+      description      = "Check Testnet nodes and decrease CPU limits if error, or scale as needed if increased traffic."
+      summary          = "[TESTNET]CPU USAGE HIGH FOR 1H"
+    }
+    is_paused = false
+
+    notification_settings {
+      contact_point = "SRE On-call"
+    }
+  }
+  rule {
+    name      = "Testnet Node Memory Metrics"
+    condition = "K"
+
+    data {
+      ref_id     = "A"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 10800
+        to   = 0
+      }
+
+      datasource_uid = "cefmhlk39et4wb"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"cefmhlk39et4wb\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\\\"k8s_container\\\",memory_type=\\\"non-evictable\\\",project_id=\\\"near-cs-testnet\\\",location=\\\"europe-west1\\\",cluster_name=\\\"testnet\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-testnet-0\\\"}[30s]))\",\"projectName\":\"near-cs-testnet\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"A\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-testnet\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "B"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 10800
+        to   = 0
+      }
+
+      datasource_uid = "cefmhlk39et4wb"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"cefmhlk39et4wb\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\\\"k8s_container\\\",memory_type=\\\"non-evictable\\\",project_id=\\\"near-cs-testnet\\\",location=\\\"europe-west1\\\",cluster_name=\\\"testnet\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-testnet-1\\\"}[30s]))\",\"projectName\":\"near-cs-testnet\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"B\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-testnet\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "C"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 10800
+        to   = 0
+      }
+
+      datasource_uid = "cefmhlk39et4wb"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"cefmhlk39et4wb\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\\\"k8s_container\\\",memory_type=\\\"non-evictable\\\",project_id=\\\"near-cs-testnet\\\",location=\\\"europe-west1\\\",cluster_name=\\\"testnet\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-testnet-2\\\"}[30s]))\",\"projectName\":\"near-cs-testnet\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"C\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-testnet\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "D"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 10800
+        to   = 0
+      }
+
+      datasource_uid = "cefmhlk39et4wb"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"cefmhlk39et4wb\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\\\"k8s_container\\\",memory_type=\\\"non-evictable\\\",project_id=\\\"near-cs-testnet\\\",location=\\\"europe-west1\\\",cluster_name=\\\"testnet\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-testnet-3\\\"}[30s]))\",\"projectName\":\"near-cs-testnet\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"D\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-testnet\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "E"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 10800
+        to   = 0
+      }
+
+      datasource_uid = "cefmhlk39et4wb"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"cefmhlk39et4wb\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\\\"k8s_container\\\",memory_type=\\\"non-evictable\\\",project_id=\\\"near-cs-testnet\\\",location=\\\"europe-west1\\\",cluster_name=\\\"testnet\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-testnet-4\\\"}[30s]))\",\"projectName\":\"near-cs-testnet\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"E\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-testnet\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "F"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 10800
+        to   = 0
+      }
+
+      datasource_uid = "cefmhlk39et4wb"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"cefmhlk39et4wb\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\\\"k8s_container\\\",memory_type=\\\"non-evictable\\\",project_id=\\\"near-cs-testnet\\\",location=\\\"europe-west1\\\",cluster_name=\\\"testnet\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-testnet-5\\\"}[30s]))\",\"projectName\":\"near-cs-testnet\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"F\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-testnet\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "G"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 10800
+        to   = 0
+      }
+
+      datasource_uid = "cefmhlk39et4wb"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"cefmhlk39et4wb\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\\\"k8s_container\\\",memory_type=\\\"non-evictable\\\",project_id=\\\"near-cs-testnet\\\",location=\\\"europe-west1\\\",cluster_name=\\\"testnet\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-testnet-6\\\"}[30s]))\",\"projectName\":\"near-cs-testnet\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"G\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-testnet\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "H"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 10800
+        to   = 0
+      }
+
+      datasource_uid = "cefmhlk39et4wb"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"cefmhlk39et4wb\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\\\"k8s_container\\\",memory_type=\\\"non-evictable\\\",project_id=\\\"near-cs-testnet\\\",location=\\\"europe-west1\\\",cluster_name=\\\"testnet\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-testnet-7\\\"}[30s]))\",\"projectName\":\"near-cs-testnet\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"H\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-testnet\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id     = "I"
+      query_type = "promQL"
+
+      relative_time_range {
+        from = 10800
+        to   = 0
+      }
+
+      datasource_uid = "cefmhlk39et4wb"
+      model          = "{\"datasource\":{\"type\":\"stackdriver\",\"uid\":\"cefmhlk39et4wb\"},\"instant\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"promQLQuery\":{\"expr\":\"sum(avg_over_time(kubernetes_io:container_memory_limit_bytes{monitored_resource=\\\"k8s_container\\\",project_id=\\\"near-cs-testnet\\\",location=\\\"europe-west1\\\",cluster_name=\\\"testnet\\\",namespace_name=\\\"default\\\",metadata_system_top_level_controller_type=\\\"Deployment\\\",metadata_system_top_level_controller_name=\\\"multichain-testnet-0\\\"}[3h]))\",\"projectName\":\"near-cs-testnet\",\"step\":\"10s\"},\"queryType\":\"promQL\",\"range\":true,\"refId\":\"I\",\"timeSeriesList\":{\"filters\":[],\"groupBys\":[],\"projectName\":\"near-cs-testnet\",\"view\":\"FULL\"}}"
+    }
+    data {
+      ref_id = "J"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[\"J\"]},\"reducer\":{\"params\":[],\"type\":\"last\"},\"type\":\"query\"}],\"datasource\":{\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"A\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"J\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "K"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[\"K\"]},\"reducer\":{\"params\":[],\"type\":\"last\"},\"type\":\"query\"}],\"datasource\":{\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"T\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"refId\":\"K\",\"type\":\"threshold\"}"
+    }
+    data {
+      ref_id = "L"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"I\",\"hide\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"L\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "M"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"B\",\"hide\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"M\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "N"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"C\",\"hide\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"N\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "O"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"D\",\"hide\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"O\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "P"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"E\",\"hide\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"P\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "Q"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"F\",\"hide\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"Q\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "R"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"G\",\"hide\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"R\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "S"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"H\",\"hide\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"reducer\":\"last\",\"refId\":\"S\",\"type\":\"reduce\"}"
+    }
+    data {
+      ref_id = "T"
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[0,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"$J/$L > 0.8 ||\\n$M/$L > 0.8 ||\\n$N/$L > 0.8 ||\\n$O/$L > 0.8 ||\\n$P/$L > 0.8 ||\\n$Q/$L > 0.8 ||\\n$R/$L > 0.8 ||\\n$S/$L > 0.8\",\"hide\":false,\"intervalMs\":1000,\"maxDataPoints\":43200,\"refId\":\"T\",\"type\":\"math\"}"
+    }
+
+    no_data_state  = "NoData"
+    exec_err_state = "Error"
+    for            = "1m"
+    annotations = {
+      __dashboardUid__ = "cefmotn3trs3ke"
+      __panelId__      = "2"
+      description      = "Check Testnet nodes for high mem usage, if error reduce limits further, if high traffic scale accordingly"
+      summary          = "[TESTNET]TESTNET NODE MEMORY USAGE HIGH"
+    }
+    is_paused = false
+
+    notification_settings {
+      contact_point = "SRE On-call"
+    }
+  }
+}

--- a/terraform/alerts/SRE/node-hardware/resources.tf
+++ b/terraform/alerts/SRE/node-hardware/resources.tf
@@ -1,0 +1,28 @@
+terraform {
+  backend "gcs" {
+    bucket = "sig-infra-terraform"
+    prefix = "terraform/grafana/alerts/sre/node-hardware"
+  }
+
+  required_providers {
+    grafana = {
+      source  = "grafana/grafana"
+      version = "3.10.0"
+    }
+  }
+}
+
+provider "grafana" {
+  url  = data.google_secret_manager_secret_version.grafana_cloud_url.secret_data
+  auth = data.google_secret_manager_secret_version.alert_token.secret_data
+}
+
+data "google_secret_manager_secret_version" "alert_token" {
+  project = "sig-bootstrap"
+  secret  = "grafana_cloud_dashboards_token"
+}
+
+data "google_secret_manager_secret_version" "grafana_cloud_url" {
+  project = "sig-bootstrap"
+  secret  = "grafana-cloud-url"
+}

--- a/terraform/dashboards/SRE/canton-nodes/main.tf
+++ b/terraform/dashboards/SRE/canton-nodes/main.tf
@@ -1,9 +1,8 @@
-resource "grafana_folder" "sre" {
-  title = "SRE"
-  uid   = "sre"
+locals {
+  sre_folder_uid = "befk4ud4xv5s0d"
 }
 
 resource "grafana_dashboard" "canton_nodes" {
-  folder      = grafana_folder.sre.uid
+  folder      = local.sre_folder_uid
   config_json = file("${path.module}/canton_nodes.json")
 }

--- a/terraform/dashboards/SRE/canton-nodes/outputs.tf
+++ b/terraform/dashboards/SRE/canton-nodes/outputs.tf
@@ -1,5 +1,5 @@
 output "folder_uid" {
-  value = grafana_folder.sre.uid
+  value = local.sre_folder_uid
 }
 
 output "dashboard_uid" {

--- a/terraform/dashboards/SRE/node-hardware/dev_node_hardware.json
+++ b/terraform/dashboards/SRE/node-hardware/dev_node_hardware.json
@@ -1,0 +1,1353 @@
+{
+  "apiVersion": "dashboard.grafana.app/v2",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "aefmio30pt3i8e",
+    "namespace": "stacks-1067523",
+    "uid": "XSizF0c8LgnxpfvTiDXJKNQwuYePXbAE0GlCQBbSLHoX",
+    "resourceVersion": "1955668291875766402",
+    "generation": 7,
+    "creationTimestamp": "2025-03-12T14:41:50Z",
+    "labels": {
+      "grafana.app/deprecatedInternalID": "24"
+    },
+    "annotations": {
+      "grafana.app/createdBy": "user:ce16hvx2a3ev4f",
+      "grafana.app/folder": "befk4ud4xv5s0d",
+      "grafana.app/updatedBy": "user:ce16hvx2a3ev4f",
+      "grafana.app/updatedTimestamp": "2025-08-13T16:30:38Z",
+      "grafana.app/folderTitle": "SRE",
+      "grafana.app/folderUrl": "/dashboards/f/befk4ud4xv5s0d/sre"
+    }
+  },
+  "spec": {
+    "annotations": [
+      {
+        "kind": "AnnotationQuery",
+        "spec": {
+          "query": {
+            "kind": "DataQuery",
+            "group": "grafana",
+            "version": "v0",
+            "datasource": {
+              "name": "-- Grafana --"
+            },
+            "spec": {}
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "builtIn": true,
+          "legacyOptions": {
+            "type": "dashboard"
+          }
+        }
+      }
+    ],
+    "cursorSync": "Off",
+    "editable": true,
+    "elements": {
+      "panel-1": {
+        "kind": "Panel",
+        "spec": {
+          "id": 1,
+          "title": "Dev Node CPU Metrics",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "eefmhllfyfjswe"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\"k8s_container\",project_id=\"near-cs-dev\",location=\"europe-west1\",cluster_name=\"dev\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-dev-0\"}[${__interval}]))",
+                          "projectName": "near-cs-dev",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-dev",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "eefmhllfyfjswe"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\"k8s_container\",project_id=\"near-cs-dev\",location=\"europe-west1\",cluster_name=\"dev\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-dev-1\"}[${__interval}]))",
+                          "projectName": "near-cs-dev",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-dev",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "eefmhllfyfjswe"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\"k8s_container\",project_id=\"near-cs-dev\",location=\"europe-west1\",cluster_name=\"dev\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-dev-2\"}[${__interval}]))",
+                          "projectName": "near-cs-dev",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-dev",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "eefmhllfyfjswe"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\"k8s_container\",project_id=\"near-cs-dev\",location=\"europe-west1\",cluster_name=\"dev\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-dev-3\"}[${__interval}]))",
+                          "projectName": "near-cs-dev",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-dev",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "D",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "eefmhllfyfjswe"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\"k8s_container\",project_id=\"near-cs-dev\",location=\"europe-west1\",cluster_name=\"dev\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-dev-4\"}[${__interval}]))",
+                          "projectName": "near-cs-dev",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-dev",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "E",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "eefmhllfyfjswe"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\"k8s_container\",project_id=\"near-cs-dev\",location=\"europe-west1\",cluster_name=\"dev\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-dev-5\"}[${__interval}]))",
+                          "projectName": "near-cs-dev",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-dev",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "F",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "eefmhllfyfjswe"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\"k8s_container\",project_id=\"near-cs-dev\",location=\"europe-west1\",cluster_name=\"dev\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-dev-6\"}[${__interval}]))",
+                          "projectName": "near-cs-dev",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-dev",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "G",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "eefmhllfyfjswe"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\"k8s_container\",project_id=\"near-cs-dev\",location=\"europe-west1\",cluster_name=\"dev\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-dev-7\"}[${__interval}]))",
+                          "projectName": "near-cs-dev",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-dev",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "H",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "eefmhllfyfjswe"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\"k8s_container\",project_id=\"near-cs-dev\",location=\"europe-west1\",cluster_name=\"dev\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-dev-8\"}[${__interval}]))",
+                          "projectName": "near-cs-dev",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-dev",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "I",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "eefmhllfyfjswe"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\"k8s_container\",project_id=\"near-cs-dev\",location=\"europe-west1\",cluster_name=\"dev\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-dev-9\"}[${__interval}]))",
+                          "projectName": "near-cs-dev",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-dev",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "J",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "eefmhllfyfjswe"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\"k8s_container\",project_id=\"near-cs-dev\",location=\"europe-west1\",cluster_name=\"dev\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-dev-10\"}[${__interval}]))",
+                          "projectName": "near-cs-dev",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-dev",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "K",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "eefmhllfyfjswe"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\"k8s_container\",project_id=\"near-cs-dev\",location=\"europe-west1\",cluster_name=\"dev\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-dev-11\"}[${__interval}]))",
+                          "projectName": "near-cs-dev",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-dev",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "L",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "eefmhllfyfjswe"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(avg_over_time(kubernetes_io:container_cpu_limit_cores{monitored_resource=\"k8s_container\",project_id=\"near-cs-dev\",location=\"europe-west1\",cluster_name=\"dev\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-dev-0\"}[${__interval}]))",
+                          "projectName": "near-cs-dev",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-dev",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "M",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "12.2.0-16677249643",
+            "spec": {
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "percentage",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 80,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "dashed"
+                    }
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "M"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "CPU Limit"
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "#ff0000",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-dev-0"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-dev-1"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "C"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-dev-2"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "D"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-dev-3"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "E"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-dev-4"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "F"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-dev-5"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "G"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-dev-6"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "H"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-dev-7"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "I"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-dev-8"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "J"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-dev-9"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "K"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-dev-10"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "L"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-dev-11"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "panel-2": {
+        "kind": "Panel",
+        "spec": {
+          "id": 2,
+          "title": "Dev Node Memory Metrics",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "eefmhllfyfjswe"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\"k8s_container\",memory_type=\"non-evictable\",project_id=\"near-cs-dev\",location=\"europe-west1\",cluster_name=\"dev\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-dev-0\"}[${__interval}]))",
+                          "projectName": "near-cs-dev",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-dev",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "eefmhllfyfjswe"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\"k8s_container\",memory_type=\"non-evictable\",project_id=\"near-cs-dev\",location=\"europe-west1\",cluster_name=\"dev\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-dev-1\"}[${__interval}]))",
+                          "projectName": "near-cs-dev",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-dev",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "eefmhllfyfjswe"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\"k8s_container\",memory_type=\"non-evictable\",project_id=\"near-cs-dev\",location=\"europe-west1\",cluster_name=\"dev\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-dev-2\"}[${__interval}]))",
+                          "projectName": "near-cs-dev",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-dev",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "eefmhllfyfjswe"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\"k8s_container\",memory_type=\"non-evictable\",project_id=\"near-cs-dev\",location=\"europe-west1\",cluster_name=\"dev\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-dev-3\"}[${__interval}]))",
+                          "projectName": "near-cs-dev",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-dev",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "D",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "eefmhllfyfjswe"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\"k8s_container\",memory_type=\"non-evictable\",project_id=\"near-cs-dev\",location=\"europe-west1\",cluster_name=\"dev\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-dev-4\"}[${__interval}]))",
+                          "projectName": "near-cs-dev",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-dev",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "E",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "eefmhllfyfjswe"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\"k8s_container\",memory_type=\"non-evictable\",project_id=\"near-cs-dev\",location=\"europe-west1\",cluster_name=\"dev\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-dev-5\"}[${__interval}]))",
+                          "projectName": "near-cs-dev",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-dev",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "F",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "eefmhllfyfjswe"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\"k8s_container\",memory_type=\"non-evictable\",project_id=\"near-cs-dev\",location=\"europe-west1\",cluster_name=\"dev\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-dev-6\"}[${__interval}]))",
+                          "projectName": "near-cs-dev",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-dev",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "G",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "eefmhllfyfjswe"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\"k8s_container\",memory_type=\"non-evictable\",project_id=\"near-cs-dev\",location=\"europe-west1\",cluster_name=\"dev\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-dev-7\"}[${__interval}]))",
+                          "projectName": "near-cs-dev",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-dev",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "H",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "eefmhllfyfjswe"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\"k8s_container\",memory_type=\"non-evictable\",project_id=\"near-cs-dev\",location=\"europe-west1\",cluster_name=\"dev\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-dev-8\"}[${__interval}]))",
+                          "projectName": "near-cs-dev",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-dev",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "I",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "eefmhllfyfjswe"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\"k8s_container\",memory_type=\"non-evictable\",project_id=\"near-cs-dev\",location=\"europe-west1\",cluster_name=\"dev\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-dev-9\"}[${__interval}]))",
+                          "projectName": "near-cs-dev",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-dev",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "J",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "eefmhllfyfjswe"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\"k8s_container\",memory_type=\"non-evictable\",project_id=\"near-cs-dev\",location=\"europe-west1\",cluster_name=\"dev\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-dev-10\"}[${__interval}]))",
+                          "projectName": "near-cs-dev",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-dev",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "K",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "eefmhllfyfjswe"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\"k8s_container\",memory_type=\"non-evictable\",project_id=\"near-cs-dev\",location=\"europe-west1\",cluster_name=\"dev\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-dev-11\"}[${__interval}]))",
+                          "projectName": "near-cs-dev",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-dev",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "L",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "eefmhllfyfjswe"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(avg_over_time(kubernetes_io:container_memory_limit_bytes{monitored_resource=\"k8s_container\",project_id=\"near-cs-dev\",location=\"europe-west1\",cluster_name=\"dev\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-dev-0\"}[${__interval}]))",
+                          "projectName": "near-cs-dev",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-dev",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "M",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "12.2.0-16677249643",
+            "spec": {
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "bytes",
+                  "thresholds": {
+                    "mode": "percentage",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 80,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "dashed"
+                    }
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "M"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Memory Limit"
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "#ff0000",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-dev-0"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-dev-1"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "C"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-dev-2"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "D"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-dev-3"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "E"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-dev-4"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "F"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-dev-5"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "G"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-dev-6"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "H"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-dev-7"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "I"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-dev-8"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "J"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-dev-9"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "K"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-dev-10"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "L"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-dev-11"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "GridLayout",
+      "spec": {
+        "items": [
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 0,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-1"
+              }
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 12,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-2"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "liveNow": false,
+    "preload": false,
+    "tags": [],
+    "timeSettings": {
+      "timezone": "browser",
+      "from": "now-6h",
+      "to": "now",
+      "autoRefresh": "",
+      "autoRefreshIntervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "hideTimepicker": false,
+      "fiscalYearStartMonth": 0
+    },
+    "title": "Dev Node Hardware Metrics",
+    "variables": []
+  }
+}

--- a/terraform/dashboards/SRE/node-hardware/main.tf
+++ b/terraform/dashboards/SRE/node-hardware/main.tf
@@ -1,0 +1,18 @@
+locals {
+  sre_folder_uid = "befk4ud4xv5s0d"
+}
+
+resource "grafana_dashboard" "dev_node_hardware" {
+  folder      = local.sre_folder_uid
+  config_json = file("${path.module}/dev_node_hardware.json")
+}
+
+resource "grafana_dashboard" "mainnet_node_hardware" {
+  folder      = local.sre_folder_uid
+  config_json = file("${path.module}/mainnet_node_hardware.json")
+}
+
+resource "grafana_dashboard" "testnet_node_hardware" {
+  folder      = local.sre_folder_uid
+  config_json = file("${path.module}/testnet_node_hardware.json")
+}

--- a/terraform/dashboards/SRE/node-hardware/mainnet_node_hardware.json
+++ b/terraform/dashboards/SRE/node-hardware/mainnet_node_hardware.json
@@ -1,0 +1,469 @@
+{
+  "apiVersion": "dashboard.grafana.app/v2",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "defk916x2e0hsd",
+    "namespace": "stacks-1067523",
+    "uid": "oyLdUDzvpbvGdZ3GVe1W8s9VpbzwqZXUXhH0BoTKHssX",
+    "resourceVersion": "1900249498383286331",
+    "generation": 7,
+    "creationTimestamp": "2025-03-11T23:26:42Z",
+    "labels": {
+      "grafana.app/deprecatedInternalID": "23"
+    },
+    "annotations": {
+      "grafana.app/createdBy": "user:ce16hvx2a3ev4f",
+      "grafana.app/folder": "befk4ud4xv5s0d",
+      "grafana.app/updatedBy": "user:ce16hvx2a3ev4f",
+      "grafana.app/updatedTimestamp": "2025-03-13T18:16:06Z",
+      "grafana.app/folderTitle": "SRE",
+      "grafana.app/folderUrl": "/dashboards/f/befk4ud4xv5s0d/sre"
+    }
+  },
+  "spec": {
+    "annotations": [
+      {
+        "kind": "AnnotationQuery",
+        "spec": {
+          "query": {
+            "kind": "DataQuery",
+            "group": "grafana",
+            "version": "v0",
+            "datasource": {
+              "name": "-- Grafana --"
+            },
+            "spec": {}
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "builtIn": true,
+          "legacyOptions": {
+            "type": "dashboard"
+          }
+        }
+      }
+    ],
+    "cursorSync": "Off",
+    "editable": true,
+    "elements": {
+      "panel-1": {
+        "kind": "Panel",
+        "spec": {
+          "id": 1,
+          "title": "Multichain Mainnet Node CPU usage",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "aefk7aww1brb4c"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\"k8s_container\",project_id=\"near-cs-mainnet\",location=\"europe-west1\",cluster_name=\"mainnet\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-mainnet-0\"}[${__interval}]))",
+                          "projectName": "near-cs-mainnet",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "alignmentPeriod": "cloud-monitoring-auto",
+                          "crossSeriesReducer": "REDUCE_NONE",
+                          "filters": [
+                            "metric.type",
+                            "=",
+                            "kubernetes.io/anthos/APIServiceOpenAPIAggregationControllerQueue1_longest_running_processor_microseconds"
+                          ],
+                          "groupBys": [],
+                          "perSeriesAligner": "ALIGN_NONE",
+                          "preprocessor": "none",
+                          "projectName": "near-cs-mainnet",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "aefk7aww1brb4c"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(avg_over_time(kubernetes_io:container_cpu_limit_cores{monitored_resource=\"k8s_container\",project_id=\"near-cs-mainnet\",location=\"europe-west1\",cluster_name=\"mainnet\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-mainnet-0\"}[${__interval}]))",
+                          "projectName": "near-cs-mainnet",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-mainnet",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "11.6.0-84214",
+            "spec": {
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "percentage",
+                    "steps": [
+                      {
+                        "value": null,
+                        "color": "green"
+                      },
+                      {
+                        "value": 80,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "dashed"
+                    }
+                  },
+                  "fieldMinMax": false
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "CPU Usage"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "CPU Limit"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "panel-2": {
+        "kind": "Panel",
+        "spec": {
+          "id": 2,
+          "title": "Mainnet Node Memory",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "aefk7aww1brb4c"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\"k8s_container\",memory_type=\"non-evictable\",project_id=\"near-cs-mainnet\",location=\"europe-west1\",cluster_name=\"mainnet\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-mainnet-0\"}[${__interval}]))",
+                          "projectName": "near-cs-mainnet",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-mainnet",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "aefk7aww1brb4c"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(avg_over_time(kubernetes_io:container_memory_limit_bytes{monitored_resource=\"k8s_container\",project_id=\"near-cs-mainnet\",location=\"europe-west1\",cluster_name=\"mainnet\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-mainnet-0\"}[${__interval}]))",
+                          "projectName": "near-cs-mainnet",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-mainnet",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "11.6.0-84214",
+            "spec": {
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "bytes",
+                  "thresholds": {
+                    "mode": "percentage",
+                    "steps": [
+                      {
+                        "value": null,
+                        "color": "green"
+                      },
+                      {
+                        "value": 80,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "dashed"
+                    }
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Mem. Usage"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Mem. Limit"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "GridLayout",
+      "spec": {
+        "items": [
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 0,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-2"
+              }
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 12,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-1"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "liveNow": false,
+    "preload": false,
+    "tags": [],
+    "timeSettings": {
+      "timezone": "browser",
+      "from": "now-3h",
+      "to": "now",
+      "autoRefresh": "1m",
+      "autoRefreshIntervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "hideTimepicker": false,
+      "fiscalYearStartMonth": 0
+    },
+    "title": "Mainnet Node Hardware metrics",
+    "variables": []
+  }
+}

--- a/terraform/dashboards/SRE/node-hardware/outputs.tf
+++ b/terraform/dashboards/SRE/node-hardware/outputs.tf
@@ -1,0 +1,11 @@
+output "folder_uid" {
+  value = local.sre_folder_uid
+}
+
+output "dashboard_uids" {
+  value = {
+    dev     = grafana_dashboard.dev_node_hardware.uid
+    mainnet = grafana_dashboard.mainnet_node_hardware.uid
+    testnet = grafana_dashboard.testnet_node_hardware.uid
+  }
+}

--- a/terraform/dashboards/SRE/node-hardware/resources.tf
+++ b/terraform/dashboards/SRE/node-hardware/resources.tf
@@ -1,0 +1,29 @@
+terraform {
+  backend "gcs" {
+    bucket = "sig-infra-terraform"
+    prefix = "terraform/grafana/dashboards/sre/node-hardware"
+  }
+
+  required_providers {
+    grafana = {
+      source  = "grafana/grafana"
+      version = "4.36.0"
+    }
+  }
+}
+
+provider "grafana" {
+  url  = data.google_secret_manager_secret_version.grafana_cloud_url.secret_data
+  auth = data.google_secret_manager_secret_version.dashboard_token.secret_data
+}
+
+data "google_secret_manager_secret_version" "dashboard_token" {
+  project = "sig-bootstrap"
+  secret  = "grafana_cloud_dashboards_token"
+  version = "2"
+}
+
+data "google_secret_manager_secret_version" "grafana_cloud_url" {
+  project = "sig-bootstrap"
+  secret  = "grafana-cloud-url"
+}

--- a/terraform/dashboards/SRE/node-hardware/testnet_node_hardware.json
+++ b/terraform/dashboards/SRE/node-hardware/testnet_node_hardware.json
@@ -1,0 +1,1033 @@
+{
+  "apiVersion": "dashboard.grafana.app/v2",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "cefmotn3trs3ke",
+    "namespace": "stacks-1067523",
+    "uid": "lLXXUvzL2llXT0bd1qRWKnzrR0diOlod7awZiQvQhzkX",
+    "resourceVersion": "1901713729909686333",
+    "generation": 5,
+    "creationTimestamp": "2025-03-12T15:50:50Z",
+    "labels": {
+      "grafana.app/deprecatedInternalID": "25"
+    },
+    "annotations": {
+      "grafana.app/createdBy": "user:ce16hvx2a3ev4f",
+      "grafana.app/folder": "befk4ud4xv5s0d",
+      "grafana.app/updatedBy": "user:ce16hvx2a3ev4f",
+      "grafana.app/updatedTimestamp": "2025-03-17T19:14:23Z",
+      "grafana.app/folderTitle": "SRE",
+      "grafana.app/folderUrl": "/dashboards/f/befk4ud4xv5s0d/sre"
+    }
+  },
+  "spec": {
+    "annotations": [
+      {
+        "kind": "AnnotationQuery",
+        "spec": {
+          "query": {
+            "kind": "DataQuery",
+            "group": "grafana",
+            "version": "v0",
+            "datasource": {
+              "name": "-- Grafana --"
+            },
+            "spec": {}
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "builtIn": true,
+          "legacyOptions": {
+            "type": "dashboard"
+          }
+        }
+      }
+    ],
+    "cursorSync": "Off",
+    "editable": true,
+    "elements": {
+      "panel-1": {
+        "kind": "Panel",
+        "spec": {
+          "id": 1,
+          "title": "Testnet Node CPU Metrics",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "cefmhlk39et4wb"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\"k8s_container\",project_id=\"near-cs-testnet\",location=\"europe-west1\",cluster_name=\"testnet\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-testnet-0\"}[${__interval}]))",
+                          "projectName": "near-cs-testnet",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-testnet",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "cefmhlk39et4wb"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\"k8s_container\",project_id=\"near-cs-testnet\",location=\"europe-west1\",cluster_name=\"testnet\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-testnet-1\"}[${__interval}]))",
+                          "projectName": "near-cs-testnet",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-testnet",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "cefmhlk39et4wb"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\"k8s_container\",project_id=\"near-cs-testnet\",location=\"europe-west1\",cluster_name=\"testnet\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-testnet-2\"}[${__interval}]))",
+                          "projectName": "near-cs-testnet",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-testnet",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "cefmhlk39et4wb"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\"k8s_container\",project_id=\"near-cs-testnet\",location=\"europe-west1\",cluster_name=\"testnet\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-testnet-3\"}[${__interval}]))",
+                          "projectName": "near-cs-testnet",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-testnet",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "D",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "cefmhlk39et4wb"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\"k8s_container\",project_id=\"near-cs-testnet\",location=\"europe-west1\",cluster_name=\"testnet\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-testnet-4\"}[${__interval}]))",
+                          "projectName": "near-cs-testnet",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-testnet",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "E",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "cefmhlk39et4wb"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\"k8s_container\",project_id=\"near-cs-testnet\",location=\"europe-west1\",cluster_name=\"testnet\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-testnet-5\"}[${__interval}]))",
+                          "projectName": "near-cs-testnet",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-testnet",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "F",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "cefmhlk39et4wb"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\"k8s_container\",project_id=\"near-cs-testnet\",location=\"europe-west1\",cluster_name=\"testnet\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-testnet-6\"}[${__interval}]))",
+                          "projectName": "near-cs-testnet",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-testnet",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "G",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "cefmhlk39et4wb"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\"k8s_container\",project_id=\"near-cs-testnet\",location=\"europe-west1\",cluster_name=\"testnet\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-testnet-7\"}[${__interval}]))",
+                          "projectName": "near-cs-testnet",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-testnet",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "H",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "cefmhlk39et4wb"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(avg_over_time(kubernetes_io:container_cpu_limit_cores{monitored_resource=\"k8s_container\",project_id=\"near-cs-testnet\",location=\"europe-west1\",cluster_name=\"testnet\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-testnet-0\"}[${__interval}]))",
+                          "projectName": "near-cs-testnet",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-testnet",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "I",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "11.6.0-84214",
+            "spec": {
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "percentage",
+                    "steps": [
+                      {
+                        "value": null,
+                        "color": "green"
+                      },
+                      {
+                        "value": 80,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "dashed"
+                    }
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "I"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "CPU Limit"
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "#ff0000",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-testnet-0"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-testnet-1"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "C"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-testnet-2"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "D"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-testnet-3"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "E"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-testnet-4"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "F"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-testnet-5"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "G"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-testnet-6"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "H"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-testnet-7"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "panel-2": {
+        "kind": "Panel",
+        "spec": {
+          "id": 2,
+          "title": "Testnet Node Memory Metrics",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "cefmhlk39et4wb"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\"k8s_container\",memory_type=\"non-evictable\",project_id=\"near-cs-testnet\",location=\"europe-west1\",cluster_name=\"testnet\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-testnet-0\"}[${__interval}]))",
+                          "projectName": "near-cs-testnet",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-testnet",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "cefmhlk39et4wb"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\"k8s_container\",memory_type=\"non-evictable\",project_id=\"near-cs-testnet\",location=\"europe-west1\",cluster_name=\"testnet\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-testnet-1\"}[${__interval}]))",
+                          "projectName": "near-cs-testnet",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-testnet",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "cefmhlk39et4wb"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\"k8s_container\",memory_type=\"non-evictable\",project_id=\"near-cs-testnet\",location=\"europe-west1\",cluster_name=\"testnet\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-testnet-2\"}[${__interval}]))",
+                          "projectName": "near-cs-testnet",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-testnet",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "cefmhlk39et4wb"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\"k8s_container\",memory_type=\"non-evictable\",project_id=\"near-cs-testnet\",location=\"europe-west1\",cluster_name=\"testnet\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-testnet-3\"}[${__interval}]))",
+                          "projectName": "near-cs-testnet",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-testnet",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "D",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "cefmhlk39et4wb"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\"k8s_container\",memory_type=\"non-evictable\",project_id=\"near-cs-testnet\",location=\"europe-west1\",cluster_name=\"testnet\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-testnet-4\"}[${__interval}]))",
+                          "projectName": "near-cs-testnet",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-testnet",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "E",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "cefmhlk39et4wb"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\"k8s_container\",memory_type=\"non-evictable\",project_id=\"near-cs-testnet\",location=\"europe-west1\",cluster_name=\"testnet\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-testnet-5\"}[${__interval}]))",
+                          "projectName": "near-cs-testnet",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-testnet",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "F",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "cefmhlk39et4wb"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\"k8s_container\",memory_type=\"non-evictable\",project_id=\"near-cs-testnet\",location=\"europe-west1\",cluster_name=\"testnet\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-testnet-6\"}[${__interval}]))",
+                          "projectName": "near-cs-testnet",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-testnet",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "G",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "cefmhlk39et4wb"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(avg_over_time(kubernetes_io:container_memory_used_bytes{monitored_resource=\"k8s_container\",memory_type=\"non-evictable\",project_id=\"near-cs-testnet\",location=\"europe-west1\",cluster_name=\"testnet\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-testnet-7\"}[${__interval}]))",
+                          "projectName": "near-cs-testnet",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-testnet",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "H",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "stackdriver",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "cefmhlk39et4wb"
+                      },
+                      "spec": {
+                        "promQLQuery": {
+                          "expr": "sum(avg_over_time(kubernetes_io:container_memory_limit_bytes{monitored_resource=\"k8s_container\",project_id=\"near-cs-testnet\",location=\"europe-west1\",cluster_name=\"testnet\",namespace_name=\"default\",metadata_system_top_level_controller_type=\"Deployment\",metadata_system_top_level_controller_name=\"multichain-testnet-0\"}[${__interval}]))",
+                          "projectName": "near-cs-testnet",
+                          "step": "10s"
+                        },
+                        "queryType": "promQL",
+                        "timeSeriesList": {
+                          "filters": [],
+                          "projectName": "near-cs-testnet",
+                          "view": "FULL"
+                        }
+                      }
+                    },
+                    "refId": "I",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "11.6.0-84214",
+            "spec": {
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "bytes",
+                  "thresholds": {
+                    "mode": "percentage",
+                    "steps": [
+                      {
+                        "value": null,
+                        "color": "green"
+                      },
+                      {
+                        "value": 80,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "dashed"
+                    }
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "I"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Memory Limit"
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "#ff0000",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-testnet-0"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-testnet-1"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "C"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-testnet-2"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "D"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-testnet-3"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "E"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-testnet-4"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "F"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-testnet-5"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "G"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-testnet-6"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "H"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "multichain-testnet-7"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "GridLayout",
+      "spec": {
+        "items": [
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 0,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-1"
+              }
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 12,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-2"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "liveNow": false,
+    "preload": false,
+    "tags": [],
+    "timeSettings": {
+      "timezone": "browser",
+      "from": "now-6h",
+      "to": "now",
+      "autoRefresh": "",
+      "autoRefreshIntervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "hideTimepicker": false,
+      "fiscalYearStartMonth": 0
+    },
+    "title": "Testnet Node Hardware Metrics",
+    "variables": []
+  }
+}


### PR DESCRIPTION
## Summary
- import the existing SRE node hardware dashboards into Terraform
- import the existing SRE node hardware alert rule group into Terraform
- point the Canton nodes dashboard at the existing SRE folder UID instead of creating a new folder
- add CI deploy jobs for the new SRE dashboard and alert modules

## Details
This cleans up drift in the SRE Grafana folder before adding more Canton work.

Imported dashboards:
- Dev Node Hardware Metrics
- Testnet Node Hardware Metrics
- Mainnet Node Hardware metrics

Imported alerts:
- one SRE hardware rule group containing the six exported CPU and memory alerts for dev, testnet, and mainnet

Folder fix:
- use existing Grafana folder UID `befk4ud4xv5s0d`
- stop creating a new `uid = "sre"` folder in the Canton dashboard module

## Verification
- `terraform validate` for `terraform/dashboards/SRE/canton-nodes`
- `terraform validate` for `terraform/dashboards/SRE/node-hardware`
- `terraform validate` for `terraform/alerts/SRE/node-hardware`
- workflow YAML parses cleanly for:
  - `.github/workflows/deploy-cs-dashboards.yaml`
  - `.github/workflows/deploy-alerts.yaml`
