### PR TITLE
fix(dashboards): correct SRE hardware dashboard import ids

### DIFF
--- a/.github/workflows/deploy-cs-dashboards.yaml
+++ b/.github/workflows/deploy-cs-dashboards.yaml
@@ -18,6 +18,7 @@ jobs:
     outputs:
       balances: ${{ steps.filter.outputs.balances }}
       chain_signatures: ${{ steps.filter.outputs.chain_signatures }}
+      sre_folder: ${{ steps.filter.outputs.sre_folder }}
       sre_canton_nodes: ${{ steps.filter.outputs.sre_canton_nodes }}
       sre_node_hardware: ${{ steps.filter.outputs.sre_node_hardware }}
     steps:
@@ -35,6 +36,8 @@ jobs:
               - 'terraform/dashboards/Near/balances/**'
             chain_signatures:
               - 'terraform/dashboards/Near/chain-signatures/**'
+            sre_folder:
+              - 'terraform/dashboards/SRE/folder/**'
             sre_canton_nodes:
               - 'terraform/dashboards/SRE/canton-nodes/**'
             sre_node_hardware:
@@ -96,6 +99,42 @@ jobs:
 
       - name: Terraform init
         run: terraform init -input=false
+        working-directory: ${{ env.working-dir }}
+        env:
+          GOOGLE_CREDENTIALS: ${{ secrets.GCP_STATE_SA }}
+
+  deploy-sre-folder:
+    name: Deploy SRE folder
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.sre_folder == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      working-dir: ./terraform/dashboards/SRE/folder
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.7.0
+
+      - name: Terraform init
+        run: terraform init -input=false
+        working-directory: ${{ env.working-dir }}
+        env:
+          GOOGLE_CREDENTIALS: ${{ secrets.GCP_STATE_SA }}
+
+      - name: Terraform plan
+        run: terraform plan -input=false
+        working-directory: ${{ env.working-dir }}
+        env:
+          GOOGLE_CREDENTIALS: ${{ secrets.GCP_STATE_SA }}
+
+      - name: Terraform apply
+        run: terraform apply -auto-approve -input=false
         working-directory: ${{ env.working-dir }}
         env:
           GOOGLE_CREDENTIALS: ${{ secrets.GCP_STATE_SA }}

--- a/terraform/alerts/SRE/node-hardware/hardware_metrics.tf
+++ b/terraform/alerts/SRE/node-hardware/hardware_metrics.tf
@@ -1,5 +1,5 @@
 resource "grafana_rule_group" "sre_node_hardware" {
-  org_id           = 1
+  # org_id           = 1
   name             = "CPU Usage"
   folder_uid       = "befk4ud4xv5s0d"
   interval_seconds = 60

--- a/terraform/alerts/SRE/node-hardware/hardware_metrics.tf
+++ b/terraform/alerts/SRE/node-hardware/hardware_metrics.tf
@@ -1373,3 +1373,8 @@ resource "grafana_rule_group" "sre_node_hardware" {
     }
   }
 }
+
+import {
+  to = grafana_rule_group.sre_node_hardware
+  id = "befk4ud4xv5s0d:CPU Usage"
+}

--- a/terraform/dashboards/SRE/folder/main.tf
+++ b/terraform/dashboards/SRE/folder/main.tf
@@ -1,0 +1,9 @@
+resource "grafana_folder" "sre" {
+  title = "SRE"
+  uid   = "befk4ud4xv5s0d"
+}
+
+import {
+  to = grafana_folder.sre
+  id = "befk4ud4xv5s0d"
+}

--- a/terraform/dashboards/SRE/folder/outputs.tf
+++ b/terraform/dashboards/SRE/folder/outputs.tf
@@ -1,0 +1,3 @@
+output "folder_uid" {
+  value = grafana_folder.sre.uid
+}

--- a/terraform/dashboards/SRE/folder/resources.tf
+++ b/terraform/dashboards/SRE/folder/resources.tf
@@ -1,0 +1,29 @@
+terraform {
+  backend "gcs" {
+    bucket = "sig-infra-terraform"
+    prefix = "terraform/grafana/dashboards/sre/folder"
+  }
+
+  required_providers {
+    grafana = {
+      source  = "grafana/grafana"
+      version = "4.36.0"
+    }
+  }
+}
+
+provider "grafana" {
+  url  = data.google_secret_manager_secret_version.grafana_cloud_url.secret_data
+  auth = data.google_secret_manager_secret_version.dashboard_token.secret_data
+}
+
+data "google_secret_manager_secret_version" "dashboard_token" {
+  project = "sig-bootstrap"
+  secret  = "grafana_cloud_dashboards_token"
+  version = "2"
+}
+
+data "google_secret_manager_secret_version" "grafana_cloud_url" {
+  project = "sig-bootstrap"
+  secret  = "grafana-cloud-url"
+}

--- a/terraform/dashboards/SRE/node-hardware/main.tf
+++ b/terraform/dashboards/SRE/node-hardware/main.tf
@@ -7,12 +7,27 @@ resource "grafana_dashboard" "dev_node_hardware" {
   config_json = file("${path.module}/dev_node_hardware.json")
 }
 
+import {
+  to = grafana_dashboard.dev_node_hardware
+  id = "XSizF0c8LgnxpfvTiDXJKNQwuYePXbAE0GlCQBbSLHoX"
+}
+
 resource "grafana_dashboard" "mainnet_node_hardware" {
   folder      = local.sre_folder_uid
   config_json = file("${path.module}/mainnet_node_hardware.json")
 }
 
+import {
+  to = grafana_dashboard.mainnet_node_hardware
+  id = "oyLdUDzvpbvGdZ3GVe1W8s9VpbzwqZXUXhH0BoTKHssX"
+}
+
 resource "grafana_dashboard" "testnet_node_hardware" {
   folder      = local.sre_folder_uid
   config_json = file("${path.module}/testnet_node_hardware.json")
+}
+
+import {
+  to = grafana_dashboard.testnet_node_hardware
+  id = "lLXXUvzL2llXT0bd1qRWKnzrR0diOlod7awZiQvQhzkX"
 }

--- a/terraform/dashboards/SRE/node-hardware/main.tf
+++ b/terraform/dashboards/SRE/node-hardware/main.tf
@@ -9,7 +9,7 @@ resource "grafana_dashboard" "dev_node_hardware" {
 
 import {
   to = grafana_dashboard.dev_node_hardware
-  id = "XSizF0c8LgnxpfvTiDXJKNQwuYePXbAE0GlCQBbSLHoX"
+  id = "aefmio30pt3i8e"
 }
 
 resource "grafana_dashboard" "mainnet_node_hardware" {
@@ -19,7 +19,7 @@ resource "grafana_dashboard" "mainnet_node_hardware" {
 
 import {
   to = grafana_dashboard.mainnet_node_hardware
-  id = "oyLdUDzvpbvGdZ3GVe1W8s9VpbzwqZXUXhH0BoTKHssX"
+  id = "defk916x2e0hsd"
 }
 
 resource "grafana_dashboard" "testnet_node_hardware" {
@@ -29,5 +29,5 @@ resource "grafana_dashboard" "testnet_node_hardware" {
 
 import {
   to = grafana_dashboard.testnet_node_hardware
-  id = "lLXXUvzL2llXT0bd1qRWKnzrR0diOlod7awZiQvQhzkX"
+  id = "cefmotn3trs3ke"
 }


### PR DESCRIPTION
## Summary
- switch the SRE hardware dashboard import blocks to use the Grafana dashboard names from the exports
- keep the folder and resource adoption logic from the prior SRE import work unchanged

## Why
The previous import blocks used the long metadata UID from the Grafana v2 export. The provider could not resolve those objects during plan. The exported dashboard names are the identifiers that match the existing remote dashboards for import.

## Verification
- terraform init -backend=false -input=false in `terraform/dashboards/SRE/node-hardware`
- terraform validate in `terraform/dashboards/SRE/node-hardware`